### PR TITLE
Add .buffrs/config.toml registries and hierarchical packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - main-gm
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - main-gm
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: release
 on:
   push:
     tags:
-    - "v[0-9]+.[0-9]+.[0-9]+"
+    - "v[0-9]+.[0-9]+.[0-9]+(\\-gm)?"
 
 # We need this to be able to create releases.
 permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "0.8.1"
+version = "0.8.1-gm"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "0.8.1"
+version = "0.8.1-gm"
 edition = "2021"
 description = "Modern protobuf package management"
 authors = [

--- a/src/command.rs
+++ b/src/command.rs
@@ -144,7 +144,7 @@ pub async fn add(registry: &RegistryUri, dependency: &str) -> miette::Result<()>
 
     manifest
         .dependencies
-        .push(Dependency::new(&registry, repository, package, version));
+        .push(Dependency::new(registry, repository, package, version));
 
     manifest
         .write()
@@ -276,7 +276,7 @@ pub async fn publish(
     let mut manifest = Manifest::read().await?;
     let credentials = Credentials::load().await?;
     let store = PackageStore::current(config).await?;
-    let artifactory = Artifactory::new(&registry, &credentials)?;
+    let artifactory = Artifactory::new(registry, &credentials)?;
 
     if let Some(version) = version {
         if let Some(ref mut package) = manifest.package {
@@ -491,7 +491,7 @@ pub async fn login(registry: &RegistryUri) -> miette::Result<()> {
 /// Logs you out from a registry
 pub async fn logout(registry: &RegistryUri) -> miette::Result<()> {
     let mut credentials = Credentials::load().await?;
-    credentials.registry_tokens.remove(&registry);
+    credentials.registry_tokens.remove(registry);
     credentials.write().await
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -391,6 +391,17 @@ pub async fn list() -> miette::Result<()> {
 
     let protos = store.collect(&store.proto_vendor_path(), true).await;
 
+    // Canonicalize the protos
+    let protos = protos
+        .into_iter()
+        .map(|proto| {
+            proto
+                .canonicalize()
+                .into_diagnostic()
+                .wrap_err(miette!("failed to canonicalize proto path"))
+        })
+        .collect::<miette::Result<Vec<_>>>()?;
+
     let cwd = {
         let cwd = std::env::current_dir()
             .into_diagnostic()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,270 @@
+// Copyright 2023 Helsing GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{package::PackageName, registry::RegistryUri};
+use miette::{bail, ensure, miette, Context, IntoDiagnostic};
+use std::{
+    collections::HashMap,
+    ffi::OsString,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+/// Representation of the .buffrs/config.toml configuration file
+///
+/// # Example
+///
+/// ```toml
+/// [store]
+/// proto_path = "proto"
+/// proto_vendor_path = "proto/vendor"
+/// hierarchical_packages = true
+///
+/// [registries]
+/// some_org = "https://artifactory.example.com/artifactory/some-org"
+///
+/// [registry]
+/// default = "some_org"
+/// ```
+///
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Config {
+    /// Path to the configuration file
+    config_path: Option<PathBuf>,
+
+    // Interpret dots in protobuf packages as folders
+    hierarchical_packages: bool,
+
+    /// Default registry to use if none is specified
+    default_registry: Option<String>,
+
+    /// List of registries
+    registries: HashMap<String, RegistryUri>,
+
+    /// Path to the package store (default: "proto")
+    proto_path: OsString,
+
+    /// Path to the vendor directory (default: "proto/vendor")
+    proto_vendor_path: OsString,
+}
+
+impl Config {
+    const DEFAULT_PROTO_PATH: &'static str = "proto";
+    const DEFAULT_PROTO_VENDOR_PATH: &'static str = "proto/vendor";
+
+    /// Create a new configuration with default values
+    /// # Arguments
+    /// * `cwd` - Starting directory to search for the configuration file
+    ///
+    pub fn new(cwd: Option<&Path>) -> miette::Result<Self> {
+        match Self::locate_config(cwd) {
+            Some(config_path) => Self::new_from_config_file(&config_path),
+            None => Ok(Self {
+                config_path: None,
+                hierarchical_packages: false,
+                default_registry: None,
+                registries: HashMap::new(),
+                proto_path: Self::DEFAULT_PROTO_PATH.into(),
+                proto_vendor_path: Self::DEFAULT_PROTO_VENDOR_PATH.into(),
+            }),
+        }
+    }
+
+    /// Get the path to the package store
+    /// # Returns
+    /// The path to the package store
+    pub fn proto_path(&self) -> PathBuf {
+        PathBuf::from(&self.proto_path)
+    }
+
+    /// Get the path to the vendor directory
+    /// # Returns
+    /// The path to the vendor directory
+    pub fn proto_vendor_path(&self) -> PathBuf {
+        PathBuf::from(&self.proto_vendor_path)
+    }
+
+    /// Get the relative package directory
+    ///
+    /// # Arguments
+    /// * `package` - The package name
+    pub fn get_relative_package_dir(&self, package: &PackageName) -> PathBuf {
+        if self.hierarchical_packages {
+            package.to_string().replace(".", "/").into()
+        } else {
+            PathBuf::from(package.to_string())
+        }
+    }
+
+    /// Resolve the registry URI from the configuration
+    ///
+    /// # Arguments
+    /// * `registry` - The registry name or URI to resolve
+    ///
+    /// # Returns
+    /// The resolved registry URI
+    pub fn registry_or_default(&self, registry: &Option<String>) -> miette::Result<RegistryUri> {
+        match registry {
+            Some(registry) => {
+                match RegistryUri::from_str(registry) {
+                    Ok(uri) => Ok(uri),
+                    Err(_) => self.lookup_registry(registry),
+                }
+            }
+            None => match &self.default_registry {
+                Some(default_registry) => self
+                    .registries
+                    .get(default_registry)
+                    .cloned()
+                    .ok_or_else(|| {
+                        miette!("no registry provided (using --registry) and no default registry in .buffrs/config.toml")
+                    }),
+                None => bail!("no registry provided and no default registry found"),
+            },
+        }
+    }
+
+    /// Lookup a registry by name
+    ///
+    /// # Arguments
+    /// * `name` - Name of the registry to lookup
+    ///
+    /// # Returns
+    /// The registry URI
+    pub fn lookup_registry(&self, name: &str) -> miette::Result<RegistryUri> {
+        self.registries.get(name).cloned().ok_or_else(|| {
+            miette!(
+                "registry '{}' not found in {}",
+                name,
+                self.config_path
+                    .clone()
+                    .unwrap_or("config file".into())
+                    .display()
+            )
+        })
+    }
+
+    /// Locate the configuration file in the current directory or any parent directories
+    ///
+    /// # Arguments
+    /// * `cwd` - Starting directory to search for the configuration file
+    ///
+    /// # Returns
+    /// Some(PathBuf) if the configuration file is found, None otherwise
+    fn locate_config(cwd: Option<&Path>) -> Option<PathBuf> {
+        if let Some(cwd) = cwd {
+            let mut current_dir = cwd.to_owned();
+
+            loop {
+                let config_path = current_dir.join(".buffrs/config.toml");
+                if config_path.exists() {
+                    return Some(config_path);
+                }
+
+                if !current_dir.pop() {
+                    break;
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Create configuration from a TOML file
+    ///
+    /// # Arguments
+    /// * `config_path` - Path to the configuration file
+    fn new_from_config_file(config_path: &Path) -> miette::Result<Self> {
+        let config = std::fs::read_to_string(config_path)
+            .into_diagnostic()
+            .wrap_err(miette!(
+                "failed to read config file: {}",
+                config_path.display()
+            ))?;
+        let config: toml::Value = toml::from_str(&config).into_diagnostic().wrap_err(miette!(
+            "failed to parse config file: {}",
+            config_path.display()
+        ))?;
+
+        let hierarchical_packages = config
+            .get("store")
+            .and_then(|store| store.get("hierarchical_packages"))
+            .and_then(|hierarchical_packages| hierarchical_packages.as_bool())
+            .unwrap_or(false);
+
+        // Load registries from [registries] section
+        let registries = config
+            .get("registries")
+            .and_then(|registries| registries.as_table())
+            .map(|registries| {
+                registries
+                    .iter()
+                    .map(|(name, uri)| {
+                        let uri = uri
+                            .as_str()
+                            .ok_or_else(|| miette!("registry URI must be a string"))
+                            .wrap_err(miette!("invalid URI for registry '{}'", name))
+                            .wrap_err(miette!("in config file: {}", config_path.display()))?;
+                        Ok((name.to_string(), RegistryUri::from_str(uri)?))
+                    })
+                    .collect::<miette::Result<HashMap<String, RegistryUri>>>()
+            })
+            .unwrap_or_else(|| Ok(HashMap::new()))
+            .wrap_err(miette!(
+                "failed to load registries from config file: {}",
+                config_path.display()
+            ))?;
+
+        // Locate default registry from [registry.default]
+        let default_registry = config
+            .get("registry")
+            .and_then(|registry| registry.get("default"))
+            .and_then(|default| default.as_str())
+            .map(|default| default.to_string());
+
+        // Ensure that the default registry is in the list of registries
+        if let Some(ref default_registry) = default_registry {
+            ensure!(
+                registries.contains_key(default_registry),
+                "default registry '{}' not found in list of registries",
+                default_registry
+            );
+        }
+
+        // Load proto path from [store.proto_path]
+        let proto_path = config
+            .get("store")
+            .and_then(|store| store.get("proto_path"))
+            .and_then(|proto_path| proto_path.as_str())
+            .map(|proto_path| proto_path.into())
+            .unwrap_or_else(|| Self::DEFAULT_PROTO_PATH.into());
+
+        // Load proto vendor path from [store.proto_vendor_path]
+        let proto_vendor_path = config
+            .get("store")
+            .and_then(|store| store.get("proto_vendor_path"))
+            .and_then(|proto_vendor_path| proto_vendor_path.as_str())
+            .map(|proto_vendor_path| proto_vendor_path.into())
+            .unwrap_or_else(|| Self::DEFAULT_PROTO_VENDOR_PATH.into());
+
+        Ok(Self {
+            config_path: Some(config_path.to_owned()),
+            hierarchical_packages,
+            default_registry,
+            registries,
+            proto_path,
+            proto_vendor_path,
+        })
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,7 +101,7 @@ impl Config {
     /// * `package` - The package name
     pub fn get_relative_package_dir(&self, package: &PackageName) -> PathBuf {
         if self.hierarchical_packages {
-            package.to_string().replace(".", "/").into()
+            package.to_string().replace('.', "/").into()
         } else {
             PathBuf::from(package.to_string())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ pub mod resolver;
 /// Validation for buffrs packages.
 #[cfg(feature = "validation")]
 pub mod validation;
+/// Configuration file (.buffrs/config.toml) handling
+pub mod config;
 
 /// Managed directory for `buffrs`
 pub const BUFFRS_HOME: &str = ".buffrs";

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@
 
 use buffrs::command;
 use buffrs::manifest::Manifest;
-use buffrs::package::{PackageName, PackageStore};
+use buffrs::package::PackageName;
 use buffrs::registry::RegistryUri;
 use buffrs::{manifest::MANIFEST_FILE, package::PackageType};
 use clap::{Parser, Subcommand};
@@ -261,10 +261,9 @@ async fn main() -> miette::Result<()> {
                 "failed to publish `{package}` to `{registry}:{repository}`",
             ))
         }
-        Command::Lint => command::lint().await.wrap_err(miette!(
-            "failed to lint protocol buffers in `{}`",
-            PackageStore::PROTO_PATH
-        )),
+        Command::Lint => command::lint()
+            .await
+            .wrap_err(miette!("failed to lint protocol buffers",)),
         Command::Install => command::install()
             .await
             .wrap_err(miette!("failed to install dependencies for `{package}`")),
@@ -295,7 +294,6 @@ fn get_default_registry() -> Option<RegistryUri> {
     loop {
         let config_path = current_dir.join(".buffrs/config.toml");
 
-        println!("{:?}", config_path);
         if config_path.exists() {
             let config = std::fs::read_to_string(config_path)
                 .into_diagnostic()

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -395,7 +395,7 @@ pub struct Dependency {
 impl Dependency {
     /// Creates a new dependency
     pub fn new(
-        registry: RegistryUri,
+        registry: &RegistryUri,
         repository: String,
         package: PackageName,
         version: VersionReq,
@@ -405,7 +405,7 @@ impl Dependency {
             manifest: DependencyManifest {
                 repository,
                 version,
-                registry,
+                registry: registry.to_owned(),
             },
         }
     }

--- a/src/package/name.rs
+++ b/src/package/name.rs
@@ -65,7 +65,7 @@ impl PackageName {
         let is_ascii_lowercase_alphanumeric =
             |c: char| c.is_ascii_alphanumeric() && !c.is_ascii_uppercase();
         match c {
-            '-' => true,
+            '-' | '.' => true,
             c if is_ascii_lowercase_alphanumeric(c) => true,
             _ => false,
         }

--- a/src/package/store.rs
+++ b/src/package/store.rs
@@ -50,12 +50,12 @@ impl PackageStore {
 
     /// Path to the `proto` directory.
     pub fn proto_path(&self) -> PathBuf {
-        self.root.join(&self.config.proto_path())
+        self.root.join(self.config.proto_path())
     }
 
     /// Path to the vendor directory.
     pub fn proto_vendor_path(&self) -> PathBuf {
-        self.root.join(&self.config.proto_vendor_path())
+        self.root.join(self.config.proto_vendor_path())
     }
 
     /// Path to where the package contents are populated.
@@ -184,7 +184,7 @@ impl PackageStore {
 
     /// Directory for the vendored installation of a package
     pub fn locate(&self, package: &PackageName) -> PathBuf {
-        let package_path = self.config.get_relative_package_dir(&package);
+        let package_path = self.config.get_relative_package_dir(package);
         self.proto_vendor_path().join(package_path)
     }
 

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -31,7 +31,7 @@ impl Artifactory {
     pub fn new(registry: &RegistryUri, credentials: &Credentials) -> miette::Result<Self> {
         Ok(Self {
             registry: registry.clone(),
-            token: credentials.registry_tokens.get(&registry).cloned(),
+            token: credentials.registry_tokens.get(registry).cloned(),
             client: reqwest::Client::builder()
                 .redirect(reqwest::redirect::Policy::none())
                 .build()

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -28,7 +28,7 @@ pub struct Artifactory {
 
 impl Artifactory {
     /// Creates a new instance of an Artifactory registry client
-    pub fn new(registry: RegistryUri, credentials: &Credentials) -> miette::Result<Self> {
+    pub fn new(registry: &RegistryUri, credentials: &Credentials) -> miette::Result<Self> {
         Ok(Self {
             registry: registry.clone(),
             token: credentials.registry_tokens.get(&registry).cloned(),

--- a/src/registry/cache.rs
+++ b/src/registry/cache.rs
@@ -147,7 +147,7 @@ mod tests {
         // had published.
         let fetched = registry
             .download(Dependency::new(
-                registry_uri,
+                &registry_uri,
                 "test-repo".into(),
                 "test-api".parse().unwrap(),
                 "=0.1.0".parse().unwrap(),

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -155,7 +155,7 @@ mod tests {
         let repository = String::from("my-repo");
         let package = PackageName::from_str("package").unwrap();
         let version = VersionReq::from_str(version).unwrap();
-        Dependency::new(registry, repository, package, version)
+        Dependency::new(&registry, repository, package, version)
     }
 
     #[test]

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -119,8 +119,7 @@ fn map_registry_name(value: &str) -> Option<RegistryUri> {
                 .get("registries")
                 .and_then(|registries| registries.get(value))
                 .and_then(|registry| registry.as_str())
-                .map(|registry| RegistryUri::from_str(registry).ok())
-                .flatten();
+                .and_then(|registry| RegistryUri::from_str(registry).ok());
 
             if let Some(registry) = registry {
                 return Some(registry);
@@ -128,10 +127,9 @@ fn map_registry_name(value: &str) -> Option<RegistryUri> {
         }
 
         if !current_dir.pop() {
-            break;
+            break None;
         }
     }
-    todo!()
 }
 
 #[derive(Error, Debug)]

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -172,11 +172,12 @@ impl DependencyGraph {
                 return Ok(cached);
             }
 
-            let registry = Artifactory::new(dependency.manifest.registry.clone(), credentials)
-                .wrap_err(DownloadError {
+            let registry = Artifactory::new(&dependency.manifest.registry, credentials).wrap_err(
+                DownloadError {
                     name: dependency.package.clone(),
                     version: dependency.manifest.version.clone(),
-                })?;
+                },
+            )?;
 
             let package = registry
                 .download(dependency.with_version(&local_locked.version))
@@ -190,11 +191,12 @@ impl DependencyGraph {
 
             Ok(package)
         } else {
-            let registry = Artifactory::new(dependency.manifest.registry.clone(), credentials)
-                .wrap_err(DownloadError {
+            let registry = Artifactory::new(&dependency.manifest.registry, credentials).wrap_err(
+                DownloadError {
                     name: dependency.package.clone(),
                     version: dependency.manifest.version.clone(),
-                })?;
+                },
+            )?;
 
             registry
                 .download(dependency.clone())


### PR DESCRIPTION
Modified version with these additional features.

1. _.buffrs/config.toml_ files allow specificying default registry and registry aliases
2. Package names may contain dots, which are mapped to sub-folders

