### PR TITLE
Implement buf.yaml file generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,13 +254,14 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "0.9.1-gm2"
+version = "0.9.2-gm3"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_fs",
  "async-recursion",
  "axum",
+ "bitflags",
  "bytes",
  "clap",
  "diff-struct",
@@ -274,6 +275,7 @@ dependencies = [
  "paste",
  "predicates",
  "pretty_assertions",
+ "pretty_yaml",
  "protobuf",
  "protobuf-parse",
  "reqwest",
@@ -281,6 +283,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
+ "serde_yml",
  "sha2",
  "similar-asserts",
  "strum",
@@ -412,6 +415,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpufeatures"
@@ -1429,6 +1438,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +1778,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_yaml"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda9a64ee7296e82d1e0f4389383e6a7d8e6e2487d8391f7d028c131395fd376"
+dependencies = [
+ "rowan",
+ "tiny_pretty",
+ "yaml_parser",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,7 +1853,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls",
  "socket2",
  "thiserror",
@@ -1840,7 +1870,7 @@ dependencies = [
  "bytes",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls",
  "slab",
  "thiserror",
@@ -1997,10 +2027,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.15.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -2202,6 +2250,21 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]
@@ -2435,6 +2498,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
+
+[[package]]
 name = "textwrap"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,6 +2543,12 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
+
+[[package]]
+name = "tiny_pretty"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3f46f0549180b9c6f7f76270903f1a06867c43a03998b99dce81aa1760c3b2"
 
 [[package]]
 name = "tinyvec"
@@ -3100,6 +3175,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "yaml_parser"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c551c67700672ec050a94d5d917487c0ecd644a12735133df65564779c5b7b"
+dependencies = [
+ "rowan",
+ "winnow",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "0.9.2-gm3"
+version = "0.9.2-gm"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "0.9.2-gm3"
+version = "0.9.2-gm"
 edition = "2021"
 description = "Modern protobuf package management"
 authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "0.9.1-gm2"
+version = "0.9.2-gm3"
 edition = "2021"
 description = "Modern protobuf package management"
 authors = [
@@ -40,6 +40,7 @@ git = []
 [dependencies]
 async-recursion = "1.0.5"
 anyhow = { version = "1.0", optional = true }
+bitflags = { version = "2.6" }
 bytes = "1.0"
 clap = { version = "4.3", features = ["cargo", "derive"] }
 diff-struct = { version = "0.5.3", optional = true }
@@ -48,12 +49,14 @@ hex = "0.4.3"
 home = "0.5.5"
 human-panic = "2.0.2"
 miette = { version = "7.2.0", features = ["fancy"] }
+pretty_yaml = { version = "0.5.0" }
 protobuf = { version = "3.3.0", optional = true }
 protobuf-parse = { version = "3.3.0", optional = true }
 reqwest = { version = "0.12.9", features = ["rustls-tls-native-roots"], default-features = false }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yml = { version = "0.0.12" }
 tar = "0.4"
 thiserror = "1.0.49"
 tokio = { version = "^1.26", features = ["fs", "rt", "macros", "process", "io-std", "tracing"] }

--- a/src/buf_yaml.rs
+++ b/src/buf_yaml.rs
@@ -1,0 +1,280 @@
+use miette::{miette, IntoDiagnostic};
+use pretty_yaml::config::FormatOptions;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fs, io::Write};
+
+use crate::package::PackageStore;
+
+const BUF_YAML_FILE: &str = "buf.yaml";
+
+/// Representation of a Buf YAML file
+pub struct BufYamlFile {
+    config: Config,
+}
+
+impl BufYamlFile {
+    /// Create default `BufYamlFile` with default values
+    pub fn new() -> Self {
+        let config: Config = serde_yml::from_str(DEFAULT_YAML).unwrap();
+        Self { config }
+    }
+
+    /// Create a new `BufYamlFile` from a string
+    pub fn new_from_str(s: &str) -> miette::Result<Self> {
+        let config: Config = serde_yml::from_str(s).into_diagnostic()?;
+
+        // Version needs to be v2
+        if config.version != "v2" {
+            return Err(miette!("Only v2 is supported for Buf YAML files"));
+        }
+
+        Ok(Self { config })
+    }
+
+    /// Serialize the `BufYamlFile` to a string
+    pub fn to_string(&self) -> miette::Result<String> {
+        let yaml = serde_yml::to_string(&self.config).into_diagnostic()?;
+
+        // prettyfy the output
+        let options = FormatOptions::default();
+        pretty_yaml::format_text(&yaml, &options).into_diagnostic()
+    }
+
+    /// Load `BufYamlFile` from a YAML file
+    pub fn from_file() -> miette::Result<Self> {
+        let yaml_content = fs::read_to_string(BUF_YAML_FILE).into_diagnostic()?;
+        Self::new_from_str(&yaml_content)
+    }
+
+    /// Write `BufYamlFile` to a YAML file
+    pub fn to_file(&self) -> miette::Result<()> {
+        let yaml_content = self.to_string()?;
+        let mut file = fs::File::create(BUF_YAML_FILE).into_diagnostic()?;
+        file.write_all(yaml_content.as_bytes()).into_diagnostic()?;
+        Ok(())
+    }
+
+    /// Clear all modules from the Buf YAML file
+    pub fn clear_modules(&mut self) {
+        self.config.modules.clear();
+    }
+
+    /// Add non-vendor module to the Buf YAML file
+    pub fn add_module(&mut self) {
+        let proto_path = PackageStore::PROTO_PATH.to_string();
+        let proto_vendor_path = PackageStore::PROTO_VENDOR_PATH.to_string();
+
+        self.config.modules.push(Module {
+            path: proto_path,
+            excludes: vec![proto_vendor_path],
+            ..Default::default()
+        });
+    }
+
+    /// Add vendor modules to the Buf YAML file
+    pub fn set_vendor_modules(&mut self, vendor_modules: Vec<String>) {
+        let proto_vendor_path = PackageStore::PROTO_VENDOR_PATH.to_string();
+
+        // Add vendor modules
+        for module in vendor_modules {
+            self.config.modules.push(Module {
+                path: format!("{}/{}", &proto_vendor_path, module),
+                ..Default::default()
+            });
+        }
+    }
+}
+
+impl Default for BufYamlFile {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Default buf.yaml file
+const DEFAULT_YAML: &str = r#"
+version: v2
+
+modules:
+lint:
+  use:
+    - DEFAULT
+  except:
+    - PACKAGE_VERSION_SUFFIX
+breaking:
+  use:
+    - FILE
+deps:
+  - buf.build/googleapis/googleapis
+  - buf.build/grpc/grpc
+"#;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Config {
+    version: String,
+    modules: Vec<Module>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    deps: Vec<String>,
+    lint: Option<LintConfig>,
+    breaking: Option<BreakingConfig>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    plugins: Vec<Plugin>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct Module {
+    path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    excludes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    includes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    lint: Option<LintConfig>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    disallow_comment_ignores: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    enum_zero_value_suffix: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    rpc_allow_same_request_response: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    rpc_allow_google_protobuf_empty_requests: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    rpc_allow_google_protobuf_empty_responses: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    service_suffix: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    disable_builtin: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    breaking: Option<BreakingConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct LintConfig {
+    #[serde(rename = "use", default, skip_serializing_if = "Vec::is_empty")]
+    use_rules: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    except: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    ignore: Vec<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    ignore_only: HashMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BreakingConfig {
+    #[serde(rename = "use", default, skip_serializing_if = "Vec::is_empty")]
+    use_rules: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    except: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    ignore_unstable_packages: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    disable_builtin: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Plugin {
+    plugin: String,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    options: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PluginOptions {
+    timestamp_suffix: Option<String>,
+}
+
+fn is_false(b: impl std::borrow::Borrow<bool>) -> bool {
+    !b.borrow()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    #[test]
+    fn test_gen_default_buf_yaml() {}
+
+    #[test]
+    fn test_new_from_str() {
+        let buf_yaml = BufYamlFile::new_from_str(SAMPLE_YAML).unwrap();
+
+        // serialize to file
+        let serialized = buf_yaml.to_string().unwrap();
+
+        let writer = std::fs::File::create("buf.yaml").unwrap();
+        let mut writer = std::io::BufWriter::new(writer);
+        writer.write_all(serialized.as_bytes()).unwrap();
+    }
+
+    const SAMPLE_YAML: &str = r#"
+version: v2
+modules:
+  - path: proto/foo
+    name: buf.build/acme/foo
+  - path: proto/bar
+    name: buf.build/acme/bar
+    excludes:
+      - proto/bar/a
+      - proto/bar/b/e.proto
+    lint:
+      use:
+        - STANDARD
+      except:
+        - IMPORT_USED
+      ignore:
+        - proto/bar/c
+      ignore_only:
+        ENUM_ZERO_VALUE_SUFFIX:
+          - proto/bar/a
+          - proto/bar/b/f.proto
+    disallow_comment_ignores: false
+    enum_zero_value_suffix: _UNSPECIFIED
+    rpc_allow_same_request_response: false
+    rpc_allow_google_protobuf_empty_requests: false
+    rpc_allow_google_protobuf_empty_responses: false
+    service_suffix: Service
+    disable_builtin: false
+    breaking:
+      use:
+        - FILE
+      except:
+        - EXTENSION_MESSAGE_NO_DELETE
+      ignore_unstable_packages: true
+      disable_builtin: false
+  - path: proto/common
+    module: buf.build/acme/weather
+    includes:
+      - proto/common/weather
+  - path: proto/common
+    module: buf.build/acme/location
+    includes:
+      - proto/common/location
+    excludes:
+      - proto/common/location/test
+  - path: proto/common
+    module: buf.build/acme/other
+    excludes:
+      - proto/common/location
+      - proto/common/weather
+deps:
+  - buf.build/acme/paymentapis
+  - buf.build/acme/pkg:47b927cbb41c4fdea1292bafadb8976f
+  - buf.build/googleapis/googleapis:v1beta1.1.0
+lint:
+  use:
+    - STANDARD
+    - TIMESTAMP_SUFFIX
+breaking:
+  use:
+    - FILE
+plugins:
+  - plugin: plugin-timestamp-suffix
+    options:
+      timestamp_suffix: _time
+"#;
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -511,18 +511,16 @@ pub async fn install(
             // under proto/** (but not under proto/vendor/**)
             let vendor_path = store.proto_vendor_path();
             let mut has_protos = false;
-            for entry in WalkDir::new(store.proto_path()) {
-                if let Ok(entry) = entry {
-                    if entry.path().is_file() {
-                        let path = entry.path();
-                        if path.starts_with(&vendor_path) {
-                            continue;
-                        }
+            for entry in WalkDir::new(store.proto_path()).into_iter().flatten() {
+                if entry.path().is_file() {
+                    let path = entry.path();
+                    if path.starts_with(&vendor_path) {
+                        continue;
+                    }
 
-                        if path.extension().map_or(false, |ext| ext == "proto") {
-                            has_protos = true;
-                            break;
-                        }
+                    if path.extension().map_or(false, |ext| ext == "proto") {
+                        has_protos = true;
+                        break;
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,9 @@ pub mod resolver;
 #[cfg(feature = "validation")]
 pub mod validation;
 
+/// buf.yaml generation
+pub mod buf_yaml;
+
 /// Managed directory for `buffrs`
 pub const BUFFRS_HOME: &str = ".buffrs";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,7 +283,7 @@ async fn main() -> miette::Result<()> {
             no_buf_yaml,
         } => {
             let mut generation_flags = GenerationFlags::empty();
-            if no_buf_yaml == false {
+            if !no_buf_yaml {
                 generation_flags |= GenerationFlags::BUF_YAML;
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,10 +331,10 @@ fn infer_package_type(lib: bool, api: bool) -> Option<PackageType> {
 }
 
 /// Retrieve and merge default arguments with user-provided arguments
-/// 
+///
 /// # Arguments
 /// * `config` - The configuration object
-/// 
+///
 /// # Returns
 /// A vector of arguments with default arguments merged in
 fn merge_with_default_args(config: &Config) -> Vec<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,6 +331,12 @@ fn infer_package_type(lib: bool, api: bool) -> Option<PackageType> {
 }
 
 /// Retrieve and merge default arguments with user-provided arguments
+/// 
+/// # Arguments
+/// * `config` - The configuration object
+/// 
+/// # Returns
+/// A vector of arguments with default arguments merged in
 fn merge_with_default_args(config: &Config) -> Vec<String> {
     let mut args: Vec<String> = std::env::args().collect();
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -400,6 +400,11 @@ impl DependencyGraph {
     pub fn get(&self, name: &PackageName) -> Option<&ResolvedDependency> {
         self.entries.get(name)
     }
+
+    /// Returns a list of all package names in the dependency graph
+    pub fn get_package_names(&self) -> Vec<PackageName> {
+        self.entries.keys().cloned().collect()
+    }
 }
 
 impl IntoIterator for DependencyGraph {


### PR DESCRIPTION
- Subcommand `buffrs install`:
	- Added flag `--buf-yaml` to generate _buf.yaml_ file when installing dependencies, which can be used with `buf lint` and `buf generate` (if a matching _buf.gen.yaml_ is added)

- Config file (_<repo>/.buffrs/config.toml_):
	- Add section `[commands]` to list default arguments for subcommands. Example usage:
	 ```toml
	[registry]
	default = "globus"
	
	[registries]
	globus = "https://conan-us.globusmedical.com/artifactory"
	
	[commands.install]
	default_args = ["--buf-yaml"]
	```
	   