### PR TITLE
Fix repeated arguments when using default args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "0.9.2-gm"
+version = "0.9.3-gm"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "0.9.2-gm"
+version = "0.9.3-gm"
 edition = "2021"
 description = "Modern protobuf package management"
 authors = [

--- a/src/main.rs
+++ b/src/main.rs
@@ -360,9 +360,20 @@ fn merge_with_default_args(config: &Config) -> Vec<String> {
 
         // Get default args for this command
         let default_args = config.get_default_args(subcommand);
+
         if !default_args.is_empty() {
-            // Insert default arguments right after the command position
-            args.splice(command_position + 1..command_position + 1, default_args);
+            // Filter out any default arguments already provided by the user
+            let user_args: std::collections::HashSet<_> = args.iter().collect();
+            let filtered_defaults: Vec<String> = default_args
+                .into_iter()
+                .filter(|arg| !user_args.contains(arg))
+                .collect();
+
+            // Insert non-duplicate default arguments right after the command position
+            args.splice(
+                command_position + 1..command_position + 1,
+                filtered_defaults,
+            );
         }
     }
 


### PR DESCRIPTION
Fix error when both specifying arguments in the _.buffrs/config.toml_ and the command line.