### PR TITLE
feat: Add PubGrub SAT-based dependency resolution (v1.1.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,9 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
@@ -305,6 +308,7 @@ dependencies = [
  "protobuf",
  "protobuf-parse",
  "protoc-bin-vendored",
+ "pubgrub",
  "reqwest",
  "semver",
  "serde",
@@ -1772,6 +1776,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +2313,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "priority-queue"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
+dependencies = [
+ "equivalent",
+ "indexmap",
+ "serde",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +2440,20 @@ name = "protoc-bin-vendored-win32"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
+name = "pubgrub"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f5df7e552bc7edd075f5783a87fbfc21d6a546e32c16985679c488c18192d83"
+dependencies = [
+ "indexmap",
+ "log",
+ "priority-queue",
+ "rustc-hash 2.1.1",
+ "thiserror 2.0.17",
+ "version-ranges",
+]
 
 [[package]]
 name = "quinn"
@@ -2817,6 +2855,17 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
  "serde",
  "serde_core",
 ]
@@ -3409,10 +3458,14 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -3524,6 +3577,15 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version-ranges"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3595ffe225639f1e0fd8d7269dcc05d2fbfea93cfac2fea367daf1adb60aae91"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ miette = { version = "7", features = ["fancy"] }
 pretty_yaml = { version = "0.5.0" }
 protobuf = { version = "3.3.0", optional = true }
 protobuf-parse = { version = "3.3.0", optional = true }
+pubgrub = "0.3"
 reqwest = { version = "0.12", features = ["rustls-tls-native-roots"], default-features = false }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
@@ -61,7 +62,7 @@ thiserror = "1.0.49"
 tokio = { version = "^1.26", features = ["fs", "rt", "macros", "process", "io-std", "tracing"] }
 toml = "0.8.0"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2.4", features = ["serde"] }
 walkdir = "2"
 sha2 = "0.10.8"
@@ -70,7 +71,7 @@ strum = { version = "0.26.2", features = ["derive"] }
 [dev-dependencies]
 assert_cmd = "2.0"
 assert_fs = "1.0"
-axum = { version = "0.7.2", default-features = false, features = ["tokio", "http1"] }
+axum = { version = "0.7.2", default-features = false, features = ["tokio", "http1", "query", "json"] }
 fs_extra = "1.3"
 gix = { version = "0.78.0", default-features = false }
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "Modern protobuf package management"
 authors = [

--- a/docs/semver-support-plan.md
+++ b/docs/semver-support-plan.md
@@ -313,21 +313,23 @@ The PubGrub SAT-based resolver is now fully integrated into the resolver pipelin
 | File                       | Changes                                        |
 | -------------------------- | ---------------------------------------------- |
 | `src/resolver.rs`          | Added `build_with_pubgrub()` method            |
-| `src/config.rs`            | Added `use_pubgrub` config option              |
+| `src/config.rs`            | Added `use_greedy_resolver` config option      |
 | `Cargo.toml`               | Added `pubgrub = "0.3"` dependency             |
 
-### Enabling PubGrub Resolution
+### Resolver Selection
 
-Add to `.buffrs/config.toml`:
+PubGrub is the default resolver.
+
+To opt into the legacy greedy resolver, add to `.buffrs/config.toml`:
 
 ```toml
 [resolver]
-use_pubgrub = true
+use_greedy_resolver = true
 ```
 
 ### How It Works
 
-When `use_pubgrub = true`, the resolver uses a three-phase approach:
+When using PubGrub, the resolver uses a three-phase approach:
 
 1. **Discovery Phase**: Fetches all available versions and their dependencies from registries
 2. **Resolution Phase**: Runs PubGrub algorithm to find consistent version assignments
@@ -361,11 +363,12 @@ pub fn resolve(provider: &BuffrsDependencyProvider) -> ResolutionResult;
 - **Diamond dependency resolution**: Successfully resolves conflicts that greedy fails
 - **Clear error messages**: Uses `DefaultStringReporter` for human-readable failures
 - **15 unit tests**: Covers version ranges, simple/transitive/diamond resolution, conflicts
-- **Automatic fallback**: Falls back to greedy for local dependencies (not yet supported)
+- **Automatic fallback**: Falls back to greedy when multi-version resolution is required
 
 ### Limitations
 
-- **Local dependencies**: When local dependencies are present, the resolver falls back to greedy
+- **Multi-version resolution**: PubGrub produces single-version solutions per package. If
+    multi-version resolution is required, buffrs falls back to greedy.
 - **Performance**: Discovery phase downloads all versions to get dependency metadata (can be slow)
 - **Network-heavy**: Requires fetching all package versions upfront
 

--- a/docs/semver-support-plan.md
+++ b/docs/semver-support-plan.md
@@ -1,0 +1,379 @@
+# Full SemVer Support Implementation Plan
+
+This document captures the plan to implement full semantic versioning support for buffrs,
+addressing [globusmedical/ext-buffrs#16](https://github.com/globusmedical/ext-buffrs/issues/16).
+
+## Background
+
+### Current State
+
+Buffrs currently only supports **exact version pinning** (`=x.y.z`). Any other semver operator
+(caret, tilde, ranges) is rejected at download time with the error:
+
+```text
+{version} is not supported yet. Pin the exact version you want to use with '='.
+For example: '=1.0.4' instead of '^1.0.0'
+```
+
+### Upstream Status
+
+The upstream [helsing-ai/buffrs](https://github.com/helsing-ai/buffrs) has the same limitation,
+tracked in [issue #205](https://github.com/helsing-ai/buffrs/issues/205). They suggest using
+[PubGrub](https://github.com/pubgrub-rs/pubgrub) for SAT-based dependency resolution, but no
+implementation has been started.
+
+## Implementation Plan
+
+### Phase 1: Registry Version Discovery
+
+**Goal:** Query the registry for all available versions of a package.
+
+#### 1.1 Add `list_versions()` to Artifactory
+
+**File:** `src/registry/artifactory.rs`
+
+Extend the existing `get_latest_version()` logic to return all versions instead of just the maximum:
+
+```rust
+/// Retrieves all available versions of a package from artifactory
+pub async fn list_versions(
+    &self,
+    repository: String,
+    name: PackageName,
+) -> miette::Result<Vec<Version>> {
+    // Reuse artifact search query from get_latest_version()
+    // Parse and return ALL valid versions instead of just max
+}
+```
+
+#### 1.2 Create Version Selection Module
+
+**File:** `src/version.rs` (new)
+
+```rust
+use semver::{Version, VersionReq};
+
+/// Selects the best matching version from a list of available versions.
+///
+/// Returns the highest version that satisfies the requirement.
+pub fn select_version(req: &VersionReq, available: &[Version]) -> Option<Version> {
+    available
+        .iter()
+        .filter(|v| req.matches(v))
+        .max()
+        .cloned()
+}
+```
+
+### Phase 2: Resolver Changes
+
+**Goal:** Support version ranges during dependency resolution.
+
+#### 2.1 Modify Remote Dependency Resolution
+
+**File:** `src/resolver.rs`
+
+In `process_remote_dependency()`:
+
+1. Check if version requirement is already exact (has `Op::Exact`)
+2. If not exact, query `list_versions()` from registry
+3. Select best matching version using `select_version()`
+4. Create pinned dependency for download
+
+```rust
+async fn resolve_version_to_exact(
+    &self,
+    dependency: &RemoteDependency,
+) -> miette::Result<Version> {
+    let version_req = &dependency.manifest.version;
+
+    // Fast path: already exact
+    if is_exact_version(version_req) {
+        return extract_exact_version(version_req);
+    }
+
+    // Query registry for available versions
+    let registry = Artifactory::new(...)?;
+    let available = registry
+        .list_versions(dependency.manifest.repository.clone(), dependency.package.clone())
+        .await?;
+
+    // Select best match
+    select_version(version_req, &available)
+        .ok_or_else(|| miette!("no version of {} matches {}", dependency.package, version_req))
+}
+```
+
+#### 2.2 Update Download Logic
+
+**File:** `src/registry/mod.rs`
+
+Change `dependency_version_string()` to work with resolved exact versions:
+
+```rust
+/// Converts a resolved Version to artifact path string
+fn version_to_artifact_string(version: &Version) -> String {
+    if version.pre.is_empty() {
+        format!("{}.{}.{}", version.major, version.minor, version.patch)
+    } else {
+        format!("{}.{}.{}-{}", version.major, version.minor, version.patch, version.pre)
+    }
+}
+```
+
+### Phase 3: CLI Updates
+
+**Goal:** Accept version ranges in `buffrs add`.
+
+#### 3.1 Update Dependency Locator
+
+**File:** `src/command.rs`
+
+The `DependencyLocator` parser already accepts version requirements via `VersionReq::parse()`.
+Update documentation and defaults:
+
+- Default operator when none specified: `^` (caret/compatible)
+- Support all semver operators: `=`, `^`, `~`, `>`, `>=`, `<`, `<=`, `*`
+
+### Phase 4: Documentation
+
+#### 4.1 Update SemVer Reference
+
+**File:** `docs/src/reference/semver.md`
+
+Document all supported version operators with examples.
+
+## Supported Version Operators
+
+| Operator | Example   | Meaning                                      |
+| -------- | --------- | -------------------------------------------- |
+| `=`      | `=1.2.3`  | Exact version (currently the only supported) |
+| `^`      | `^1.2.3`  | Compatible updates (>=1.2.3, <2.0.0)         |
+| `~`      | `~1.2.3`  | Patch updates only (>=1.2.3, <1.3.0)         |
+| `>`      | `>1.2.3`  | Greater than                                 |
+| `>=`     | `>=1.2.3` | Greater than or equal                        |
+| `<`      | `<2.0.0`  | Less than                                    |
+| `<=`     | `<=2.0.0` | Less than or equal                           |
+| `*`      | `*`       | Any version (wildcard)                       |
+
+Multiple requirements can be combined with commas: `>=1.2.3, <2.0.0`
+
+## Files Changed
+
+| File                           | Change                                                                                   |
+| ------------------------------ | ---------------------------------------------------------------------------------------- |
+| `src/version.rs`               | New module for version selection                                                         |
+| `src/lib.rs`                   | Add `mod version`                                                                        |
+| `src/registry/artifactory.rs`  | Add `list_versions()`                                                                    |
+| `src/registry/mod.rs`          | Add `version_to_artifact_string()`, keep `dependency_version_string()` for compatibility |
+| `src/resolver.rs`              | Add version resolution before download                                                   |
+| `src/command.rs`               | Update default version operator                                                          |
+| `docs/src/reference/semver.md` | Document all operators                                                                   |
+
+## Testing Strategy
+
+1. **Unit tests** for `select_version()` with various requirements
+2. **Integration tests** with mock registry returning multiple versions
+3. **Manual testing** against real Artifactory instance
+
+## Migration Notes
+
+- Existing `Proto.toml` files with `version = "1.2.3"` will be interpreted as `^1.2.3` (compatible)
+- To maintain exact pinning, use explicit `version = "=1.2.3"`
+- `Proto.lock` continues to store exact resolved versions
+
+## Implementation Status
+
+| Phase                         | Status      | Notes                                       |
+| ----------------------------- | ----------- | ------------------------------------------- |
+| 1. Registry Version Discovery | ✅ Complete | `list_versions()` added to artifactory.rs   |
+| 2. Resolver Changes           | ✅ Complete | `resolve_version()` in resolver.rs          |
+| 3. CLI Updates                | ✅ Complete | All semver operators accepted               |
+| 4. Documentation              | ✅ Complete | `docs/src/reference/semver.md` updated      |
+| 5. Unit Tests                 | ✅ Complete | 27 tests for greedy version selection       |
+| 6. PubGrub SAT Resolution     | ✅ Complete | Full integration in resolver.rs             |
+
+## Current Limitations
+
+### Greedy Version Selection (No Backtracking)
+
+The current implementation uses a **greedy resolution strategy**: for each dependency, it
+selects the **highest version** that satisfies the version constraint. This is simple and
+fast but has limitations:
+
+#### Diamond Dependency Problem
+
+Consider this dependency graph:
+
+```text
+root
+├── package-A ^1.0.0 (resolves to A@1.5.0)
+│   └── package-C ^1.0.0 (greedy: picks C@2.0.0)
+└── package-B ^1.0.0 (resolves to B@1.3.0)
+    └── package-C >=1.2.0, <1.5.0 (CONFLICT!)
+```
+
+**What happens:**
+1. Resolver processes A first, resolves C to 2.0.0 (highest matching `^1.0.0`)
+2. Resolver processes B, needs C `>=1.2.0, <1.5.0`
+3. **Conflict!** C@2.0.0 was already selected but doesn't satisfy B's constraint
+
+**What should happen:**
+A SAT-based resolver would find C@1.4.0 (or similar) that satisfies **both** constraints.
+
+#### No Conflict Detection
+
+The current implementation doesn't detect when two dependencies require incompatible
+versions of a transitive dependency. Resolution will succeed, but the lock file may
+contain inconsistent versions.
+
+#### No Resolution Backtracking
+
+If selecting the highest version causes a conflict downstream, the resolver cannot
+"try again" with a lower version. This is a fundamental limitation of greedy approaches.
+
+### Pre-release Handling
+
+Pre-release versions (e.g., `1.0.0-alpha.1`) are only matched by:
+- Exact requirements: `=1.0.0-alpha.1`
+- Explicit pre-release comparisons: `>=1.0.0-alpha.1`
+
+They are **not** matched by caret/tilde requirements like `^1.0.0`. This follows
+standard semver semantics but can be surprising.
+
+### No Union Ranges
+
+The semver crate uses comma as AND (intersection), not OR (union). You cannot express
+"version 1.x OR version 3.x" in a single requirement.
+
+## Why SAT-Based Resolution (PubGrub)?
+
+### What is PubGrub?
+
+[PubGrub](https://github.com/pubgrub-rs/pubgrub) is a version solving algorithm developed
+by Natalie Weizenbaum for the Dart package manager. It uses **satisfiability (SAT)** 
+principles to find a consistent set of package versions.
+
+### Benefits of PubGrub
+
+1. **Handles Diamond Dependencies**
+   - Considers all constraints simultaneously
+   - Finds versions that satisfy the entire dependency graph
+   - Example: Would find C@1.4.0 in the scenario above
+
+2. **Backtracking**
+   - If a choice leads to a conflict, it "backtracks" and tries alternatives
+   - Explores the solution space systematically
+
+3. **Clear Error Messages**
+   - When no solution exists, explains *why* using "incompatibility" tracking
+   - Example: "Because A 1.5.0 requires C ^2.0.0 and B 1.3.0 requires C <1.5.0,
+     A 1.5.0 is incompatible with B 1.3.0"
+
+4. **Optimal Solutions**
+   - Can be configured to prefer newer versions while still finding valid solutions
+   - Minimizes version "downgrades" needed to resolve conflicts
+
+### When Do You Need PubGrub?
+
+You likely **don't need** SAT-based resolution if:
+- Your dependency tree is shallow (1-2 levels)
+- You have few dependencies with overlapping transitive deps
+- You control all packages in your ecosystem
+
+You likely **do need** SAT-based resolution if:
+- Complex dependency graphs with deep transitive deps
+- Multiple packages depending on shared libraries with different constraints
+- Large ecosystem with many independent package authors
+- Need clear diagnostics when resolution fails
+
+### Implementation Effort
+
+Adding PubGrub would require:
+
+1. **New dependency**: `pubgrub = "0.2"` (or later)
+2. **Trait implementation**: Implement `DependencyProvider` for the registry
+3. **Version mapping**: Convert between buffrs types and PubGrub types
+4. **Error handling**: Translate PubGrub incompatibilities to user-friendly errors
+
+Estimated effort: **3-5 days** for a basic implementation.
+
+## PubGrub Implementation (✅ Complete & Integrated)
+
+The PubGrub SAT-based resolver is now fully integrated into the resolver pipeline.
+
+### New Files
+
+| File                       | Description                                    |
+| -------------------------- | ---------------------------------------------- |
+| `src/pubgrub_resolver.rs`  | PubGrub-based SAT resolver implementation      |
+
+### Modified Files
+
+| File                       | Changes                                        |
+| -------------------------- | ---------------------------------------------- |
+| `src/resolver.rs`          | Added `build_with_pubgrub()` method            |
+| `src/config.rs`            | Added `use_pubgrub` config option              |
+| `Cargo.toml`               | Added `pubgrub = "0.3"` dependency             |
+
+### Enabling PubGrub Resolution
+
+Add to `.buffrs/config.toml`:
+
+```toml
+[resolver]
+use_pubgrub = true
+```
+
+### How It Works
+
+When `use_pubgrub = true`, the resolver uses a three-phase approach:
+
+1. **Discovery Phase**: Fetches all available versions and their dependencies from registries
+2. **Resolution Phase**: Runs PubGrub algorithm to find consistent version assignments
+3. **Download Phase**: Downloads packages with resolved versions and builds dependency graph
+
+### Key Types
+
+```rust
+/// Package identifier for PubGrub resolution
+pub enum PubGrubPackage {
+    Root,                      // The root package being resolved
+    Package(PackageName),      // A regular dependency
+}
+
+/// Convert semver::VersionReq to PubGrub Ranges<Version>
+pub fn version_req_to_ranges(req: &VersionReq) -> Ranges<Version>;
+
+/// Dependency provider for PubGrub
+pub struct BuffrsDependencyProvider {
+    packages: HashMap<PackageName, PackageInfo>,
+    root_deps: Vec<PackageDependency>,
+}
+
+/// Run PubGrub resolution
+pub fn resolve(provider: &BuffrsDependencyProvider) -> ResolutionResult;
+```
+
+### Features
+
+- **Full semver conversion**: Converts `VersionReq` to PubGrub `Ranges` for all operators
+- **Diamond dependency resolution**: Successfully resolves conflicts that greedy fails
+- **Clear error messages**: Uses `DefaultStringReporter` for human-readable failures
+- **15 unit tests**: Covers version ranges, simple/transitive/diamond resolution, conflicts
+- **Automatic fallback**: Falls back to greedy for local dependencies (not yet supported)
+
+### Limitations
+
+- **Local dependencies**: When local dependencies are present, the resolver falls back to greedy
+- **Performance**: Discovery phase downloads all versions to get dependency metadata (can be slow)
+- **Network-heavy**: Requires fetching all package versions upfront
+
+## Future Considerations
+
+- **Lazy discovery**: Fetch metadata on-demand during PubGrub resolution
+- **Local dependency support**: Extend PubGrub integration for local packages
+- **Version caching** to reduce registry queries
+- **Offline mode** using only cached/locked versions
+- **Constraint intersection** to detect conflicts early during resolution
+- **Resolution audit** command to show why specific versions were selected

--- a/docs/src/reference/publishing.md
+++ b/docs/src/reference/publishing.md
@@ -17,13 +17,13 @@ buffrs publish --registry https://artifactory.company.com/artifactory --reposito
 
 ### Options
 
-| Option              | Description                              |
-| ------------------- | ---------------------------------------- |
-| `--registry`        | Artifactory URL                          |
-| `--repository`      | Destination repository name              |
-| `--allow-dirty`     | Allow publishing with uncommitted changes |
-| `--dry-run`         | Package without uploading                |
-| `--set-version`     | Override manifest version                |
+| Option          | Description                               |
+| --------------- | ----------------------------------------- |
+| `--registry`    | Artifactory URL                           |
+| `--repository`  | Destination repository name               |
+| `--allow-dirty` | Allow publishing with uncommitted changes |
+| `--dry-run`     | Package without uploading                 |
+| `--set-version` | Override manifest version                 |
 
 ## Package Preparation
 

--- a/docs/src/reference/semver.md
+++ b/docs/src/reference/semver.md
@@ -97,7 +97,9 @@ When installing dependencies, buffrs:
 2. Selects the highest version that satisfies the requirement
 3. Records the exact resolved version in `Proto.lock`
 
-Future installs use the locked version for reproducibility.
+Future installs prefer the locked version for reproducibility when it is still compatible
+with all version constraints. If it is no longer compatible, buffrs resolves a new version
+and updates `Proto.lock`.
 
 ## Multi-version Resolution
 

--- a/docs/src/reference/semver.md
+++ b/docs/src/reference/semver.md
@@ -19,16 +19,61 @@ In `Proto.toml`, dependencies specify version requirements:
 
 ```toml
 [dependencies.my-api]
-version = "1.2.3"
+version = "^1.2.3"
 repository = "buffrs-local"
 ```
 
-### Exact Versions
+Buffrs supports the full range of semver version requirements:
 
-Currently, buffrs only supports exact version pinning:
+### Caret Requirements (Recommended)
+
+The caret (`^`) operator allows SemVer-compatible updates:
 
 ```toml
-version = "1.2.3"  # Exactly 1.2.3
+version = "^1.2.3"  # >=1.2.3, <2.0.0
+version = "^0.2.3"  # >=0.2.3, <0.3.0 (0.x is special)
+version = "^0.0.3"  # >=0.0.3, <0.0.4
+```
+
+This is the recommended default for most dependencies.
+
+### Tilde Requirements
+
+The tilde (`~`) operator allows patch-level updates only:
+
+```toml
+version = "~1.2.3"  # >=1.2.3, <1.3.0
+version = "~1.2"    # >=1.2.0, <1.3.0
+```
+
+### Exact Requirements
+
+Use `=` for exact version pinning:
+
+```toml
+version = "=1.2.3"  # Exactly 1.2.3
+```
+
+### Range Requirements
+
+Comparison operators can be combined with commas:
+
+```toml
+version = ">=1.2.0"           # 1.2.0 or higher
+version = ">1.2.0"            # Greater than 1.2.0
+version = "<2.0.0"            # Less than 2.0.0
+version = "<=2.0.0"           # 2.0.0 or lower
+version = ">=1.2.0, <2.0.0"   # Between 1.2.0 and 2.0.0
+```
+
+### Wildcard Requirements
+
+The wildcard (`*`) matches any version:
+
+```toml
+version = "*"       # Any version
+version = "1.*"     # Any 1.x version
+version = "1.2.*"   # Any 1.2.x version
 ```
 
 ### Pre-release Versions
@@ -36,10 +81,23 @@ version = "1.2.3"  # Exactly 1.2.3
 Pre-release versions follow the SemVer format:
 
 ```toml
-version = "1.0.0-alpha.1"
-version = "2.0.0-beta.3"
-version = "3.0.0-rc.1"
+version = "=1.0.0-alpha.1"
+version = "=2.0.0-beta.3"
+version = "=3.0.0-rc.1"
 ```
+
+Note: Pre-release versions are only matched when explicitly specified.
+For example, `^1.0.0` will NOT match `1.1.0-alpha.1`.
+
+## Version Resolution
+
+When installing dependencies, buffrs:
+
+1. Queries the registry for all available versions
+2. Selects the highest version that satisfies the requirement
+3. Records the exact resolved version in `Proto.lock`
+
+Future installs use the locked version for reproducibility.
 
 ## Multi-version Resolution
 
@@ -51,10 +109,12 @@ multiple versions of the same package can coexist. This is useful when:
 
 ## Best Practices
 
-1. **Start at 0.x**: Use `0.x.y` during initial development
-2. **Bump major for breaking changes**: Any protobuf field removal or renumbering
-3. **Bump minor for additions**: New messages, fields, or services
-4. **Bump patch for fixes**: Documentation or generator bug fixes
+1. **Use caret requirements**: `^1.2.3` allows compatible updates
+2. **Start at 0.x**: Use `0.x.y` during initial development
+3. **Bump major for breaking changes**: Any protobuf field removal or renumbering
+4. **Bump minor for additions**: New messages, fields, or services
+5. **Bump patch for fixes**: Documentation or generator bug fixes
+6. **Pin exact versions sparingly**: Only when necessary for stability
 
 ## See Also
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -422,12 +422,14 @@ async fn rewrite_proto_namespaces_in_dir(dir: &Path, version: &Version) -> miett
             // On Windows, files extracted from tar may be read-only. Make writable before writing.
             #[cfg(windows)]
             {
-                let mut perms = std::fs::metadata(&path)
+                let mut perms = tokio::fs::metadata(&path)
+                    .await
                     .into_diagnostic()
                     .wrap_err(miette!("failed to get metadata for {}", path.display()))?
                     .permissions();
                 perms.set_readonly(false);
-                std::fs::set_permissions(&path, perms)
+                tokio::fs::set_permissions(&path, perms)
+                    .await
                     .into_diagnostic()
                     .wrap_err(miette!("failed to set permissions for {}", path.display()))?;
             }

--- a/src/command.rs
+++ b/src/command.rs
@@ -419,6 +419,19 @@ async fn rewrite_proto_namespaces_in_dir(dir: &Path, version: &Version) -> miett
 
         // Only write if content changed
         if rewritten != contents {
+            // On Windows, files extracted from tar may be read-only. Make writable before writing.
+            #[cfg(windows)]
+            {
+                let mut perms = std::fs::metadata(&path)
+                    .into_diagnostic()
+                    .wrap_err(miette!("failed to get metadata for {}", path.display()))?
+                    .permissions();
+                perms.set_readonly(false);
+                std::fs::set_permissions(&path, perms)
+                    .into_diagnostic()
+                    .wrap_err(miette!("failed to set permissions for {}", path.display()))?;
+            }
+
             tokio::fs::write(&path, rewritten)
                 .await
                 .into_diagnostic()

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,9 @@ pub struct Config {
 struct ResolverConfig {
     allow_multiple_versions: bool,
     skip_link_safety_check: bool,
+    /// Use legacy greedy resolution instead of PubGrub SAT-based resolution.
+    /// Only use this if you encounter issues with PubGrub.
+    use_greedy_resolver: bool,
 }
 
 impl Config {
@@ -93,6 +96,7 @@ impl Config {
                 resolver: ResolverConfig {
                     allow_multiple_versions: false,
                     skip_link_safety_check: false,
+                    use_greedy_resolver: false,
                 },
             }),
         }
@@ -111,6 +115,17 @@ impl Config {
     /// that the proto namespaces don't actually conflict at runtime.
     pub fn skip_link_safety_check(&self) -> bool {
         self.resolver.skip_link_safety_check
+    }
+
+    /// Use legacy greedy resolution instead of PubGrub.
+    ///
+    /// When enabled, the resolver uses simple greedy version selection
+    /// instead of SAT-based resolution. This may fail on diamond dependencies.
+    ///
+    /// This is provided for backward compatibility and debugging. The default
+    /// PubGrub resolver should be preferred for most use cases.
+    pub fn use_greedy_resolver(&self) -> bool {
+        self.resolver.use_greedy_resolver
     }
 
     /// Parse a registry argument
@@ -256,9 +271,16 @@ impl Config {
             .and_then(|value| value.as_bool())
             .unwrap_or(false);
 
+        let use_greedy_resolver = config
+            .get("resolver")
+            .and_then(|resolver| resolver.get("use_greedy_resolver"))
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+
         ResolverConfig {
             allow_multiple_versions,
             skip_link_safety_check,
+            use_greedy_resolver,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ pub mod metadata;
 pub mod namespace_scan;
 /// Packages formats and utilities
 pub mod package;
+/// SAT-based dependency resolution using PubGrub algorithm.
+pub mod pubgrub_resolver;
 /// Supported registries
 pub mod registry;
 /// Resolve package dependencies.
@@ -48,6 +50,8 @@ pub mod resolver;
 /// Validation for buffrs packages.
 #[cfg(feature = "validation")]
 pub mod validation;
+/// Version selection and manipulation utilities.
+pub mod version;
 
 /// Managed directory for `buffrs`
 pub const BUFFRS_HOME: &str = ".buffrs";

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,11 @@ enum LockfileCommand {
 async fn main() -> miette::Result<()> {
     human_panic::setup_panic!();
 
+    // Set up tracing with an env filter that suppresses noisy dependency crates.
+    // BUFFRS_LOG can be set to override: e.g., "debug" or "buffrs=debug,pubgrub=info"
+    let filter = tracing_subscriber::EnvFilter::try_from_env("BUFFRS_LOG")
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn,buffrs=info"));
+
     tracing_subscriber::fmt()
         .compact()
         .without_time()
@@ -192,6 +197,7 @@ async fn main() -> miette::Result<()> {
         .with_file(false)
         .with_target(false)
         .with_line_number(false)
+        .with_env_filter(filter)
         .try_init()
         .unwrap();
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -349,14 +349,21 @@ impl Manifest {
                     DependencyManifest::Local(local_manifest) => {
                         // For local dependencies, check if a remote manifest is present
                         // and resolve its registry alias
+                        // Use explicit package name if provided, otherwise use the TOML key
                         let package = local_manifest
-                            .publish
-                            .as_ref()
-                            .and_then(|p| p.package.clone())
+                            .package
+                            .clone()
+                            .or_else(|| {
+                                local_manifest
+                                    .publish
+                                    .as_ref()
+                                    .and_then(|p| p.package.clone())
+                            })
                             .unwrap_or_else(|| toml_key.clone());
                         if let Some(ref remote_manifest) = local_manifest.publish {
                             let resolved_manifest =
                                 DependencyManifest::Local(LocalDependencyManifest {
+                                    package: local_manifest.package.clone(),
                                     path: local_manifest.path.clone(),
                                     publish: Some(RemoteDependencyManifest {
                                         package: remote_manifest.package.clone(),
@@ -590,8 +597,7 @@ impl Dependency {
         Self {
             package: package.clone(),
             manifest: RemoteDependencyManifest {
-                // When creating via Dependency::new, the manifest package field is None
-                // because the dependency key equals the package name
+                // No aliasing - key name matches package name
                 package: None,
                 repository,
                 version,
@@ -714,7 +720,7 @@ pub enum NamespaceOverlapPolicy {
 /// Manifest format for dependencies
 #[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RemoteDependencyManifest {
-    /// Optional explicit package name (when TOML key differs from actual package name)
+    /// Actual package name (if different from TOML key name, for aliasing)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package: Option<PackageName>,
     /// Version requirement in the buffrs format, currently only supports pinning
@@ -748,6 +754,9 @@ impl From<RemoteDependencyManifest> for DependencyManifest {
 /// Manifest format for local filesystem dependencies
 #[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LocalDependencyManifest {
+    /// Actual package name (if different from TOML key name, for aliasing)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package: Option<PackageName>,
     /// Path to local buffrs package
     pub path: PathBuf,
     /// Optional remote manifest for publishing
@@ -773,8 +782,9 @@ mod dependency_manifest_deserializer {
         {
             #[derive(Deserialize)]
             struct TempManifest {
-                path: Option<PathBuf>,
+                /// Actual package name (for aliasing: key is alias, this is real name)
                 package: Option<PackageName>,
+                path: Option<PathBuf>,
                 version: Option<VersionReq>,
                 repository: Option<String>,
                 registry: Option<RegistryRef>,
@@ -789,6 +799,7 @@ mod dependency_manifest_deserializer {
             if let Some(path) = temp.path {
                 // Deserialize as a local dependency with optional remote attributes
                 Ok(DependencyManifest::Local(LocalDependencyManifest {
+                    package: temp.package.clone(),
                     path,
                     publish: match (temp.version, temp.repository, temp.registry) {
                         (Some(version), Some(repository), Some(registry)) => {

--- a/src/package/compressed.rs
+++ b/src/package/compressed.rs
@@ -172,6 +172,10 @@ impl Package {
             );
         }
 
+        // Don't preserve Unix permissions on extraction - this prevents read-only
+        // files on Windows (tar entries have mode 0o444) and allows namespace rewriting
+        tar.set_preserve_permissions(false);
+
         fs::remove_dir_all(path).await.ok();
 
         fs::create_dir_all(path).await.into_diagnostic().wrap_err({

--- a/src/package/compressed.rs
+++ b/src/package/compressed.rs
@@ -172,10 +172,6 @@ impl Package {
             );
         }
 
-        // Don't preserve Unix permissions on extraction - this prevents read-only
-        // files on Windows (tar entries have mode 0o444) and allows namespace rewriting
-        tar.set_preserve_permissions(false);
-
         fs::remove_dir_all(path).await.ok();
 
         fs::create_dir_all(path).await.into_diagnostic().wrap_err({

--- a/src/pubgrub_resolver.rs
+++ b/src/pubgrub_resolver.rs
@@ -233,6 +233,11 @@ pub struct BuffrsDependencyProvider {
     packages: Arc<RwLock<HashMap<PackageName, PackageInfo>>>,
     /// Root package dependencies
     root_deps: Vec<PackageDependency>,
+    /// Preferred versions for reproducible installs (e.g., from Proto.lock).
+    ///
+    /// If a preferred version satisfies all constraints, it will be chosen even
+    /// if a higher version exists.
+    preferred_versions: Arc<RwLock<HashMap<PackageName, Version>>>,
 }
 
 impl BuffrsDependencyProvider {
@@ -241,6 +246,7 @@ impl BuffrsDependencyProvider {
         Self {
             packages: Arc::new(RwLock::new(HashMap::new())),
             root_deps,
+            preferred_versions: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -248,6 +254,14 @@ impl BuffrsDependencyProvider {
     pub fn add_package(&self, name: PackageName, info: PackageInfo) {
         let mut packages = self.packages.write().unwrap();
         packages.insert(name, info);
+    }
+
+    /// Sets a preferred version for a package.
+    ///
+    /// This is typically used to prefer versions pinned in `Proto.lock`.
+    pub fn set_preferred_version(&self, name: PackageName, version: Version) {
+        let mut preferred = self.preferred_versions.write().unwrap();
+        preferred.insert(name, version);
     }
 
     /// Gets the available versions for a package.
@@ -278,13 +292,31 @@ impl DependencyProvider for BuffrsDependencyProvider {
             PubGrubPackage::Package(name) => {
                 let packages = self.packages.read().unwrap();
                 if let Some(info) = packages.get(name) {
-                    // Find the highest version that matches the range
+                    // Prefer lockfile-pinned versions for reproducibility when compatible.
+                    // If dependency metadata is missing for a version, `get_dependencies` will
+                    // treat it as having no dependencies (current behavior). When metadata is
+                    // available for at least some versions, prefer versions we have metadata for.
+                    if let Some(preferred) = self.preferred_versions.read().unwrap().get(name) {
+                        let has_metadata = info.dependencies.is_empty()
+                            || info.dependencies.contains_key(preferred);
+                        if range.contains(preferred) && has_metadata {
+                            return Ok(Some(preferred.clone()));
+                        }
+                    }
+
+                    // Fall back to the highest version that matches the range.
+                    // When dependency metadata exists, restrict to versions we have metadata for.
                     let matching = info
                         .versions
                         .iter()
-                        .filter(|v| range.contains(v))
+                        .filter(|v| {
+                            range.contains(v)
+                                && (info.dependencies.is_empty()
+                                    || info.dependencies.contains_key(*v))
+                        })
                         .max()
                         .cloned();
+
                     Ok(matching)
                 } else {
                     Ok(None)
@@ -306,7 +338,16 @@ impl DependencyProvider for BuffrsDependencyProvider {
             PubGrubPackage::Package(name) => {
                 let packages = self.packages.read().unwrap();
                 if let Some(info) = packages.get(name) {
-                    let count = info.versions.iter().filter(|v| range.contains(v)).count();
+                    // Prioritize based on viable versions (those with dependency metadata).
+                    let count = info
+                        .versions
+                        .iter()
+                        .filter(|v| {
+                            range.contains(v)
+                                && (info.dependencies.is_empty()
+                                    || info.dependencies.contains_key(*v))
+                        })
+                        .count();
                     // Fewer versions = higher priority (prioritize most constrained)
                     u32::MAX - count as u32
                 } else {

--- a/src/pubgrub_resolver.rs
+++ b/src/pubgrub_resolver.rs
@@ -74,7 +74,7 @@ pub fn version_req_to_ranges(req: &VersionReq) -> SemverRanges {
         return Ranges::full();
     }
 
-    // Each comparator in a VersionReq is ANDed together
+    // Each comparator in a VersionReq is combined with AND
     let mut result = Ranges::full();
 
     for comp in &req.comparators {

--- a/src/pubgrub_resolver.rs
+++ b/src/pubgrub_resolver.rs
@@ -1,0 +1,739 @@
+//! SAT-based dependency resolution using PubGrub algorithm.
+//!
+//! This module provides a conflict-aware dependency resolver that can find
+//! consistent version assignments even in complex diamond dependency scenarios.
+//!
+//! # Advantages over Greedy Resolution
+//!
+//! - **Backtracking**: If a version choice leads to a conflict, PubGrub backtracks
+//!   and tries alternative versions.
+//! - **Diamond dependencies**: Handles cases where multiple packages depend on
+//!   a shared transitive dependency with different version constraints.
+//! - **Clear error messages**: When no solution exists, explains why with
+//!   human-readable incompatibility chains.
+//!
+//! # Example
+//!
+//! ```text
+//! root
+//! ├── A ^1.0.0  →  A@1.5.0
+//! │   └── C ^1.0.0  →  but we need C <1.5.0 from B!
+//! └── B ^1.0.0  →  B@1.3.0
+//!     └── C >=1.2.0, <1.5.0
+//!
+//! PubGrub solution: A@1.5.0, B@1.3.0, C@1.4.0 (satisfies both constraints)
+//! ```
+
+use pubgrub::{
+    DefaultStringReporter, Dependencies, DependencyConstraints, DependencyProvider,
+    PackageResolutionStatistics, PubGrubError, Ranges, Reporter,
+};
+use semver::{Comparator, Op, Version, VersionReq};
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::fmt;
+use std::sync::{Arc, RwLock};
+
+use crate::package::PackageName;
+
+/// A package identifier for PubGrub resolution.
+///
+/// Wraps `PackageName` with a special "root" variant for the resolution root.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PubGrubPackage {
+    /// The root package being resolved
+    Root,
+    /// A regular package dependency
+    Package(PackageName),
+}
+
+impl fmt::Display for PubGrubPackage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Root => write!(f, "root"),
+            Self::Package(name) => write!(f, "{}", name),
+        }
+    }
+}
+
+impl From<PackageName> for PubGrubPackage {
+    fn from(name: PackageName) -> Self {
+        Self::Package(name)
+    }
+}
+
+/// Version set type for PubGrub using semver::Version.
+pub type SemverRanges = Ranges<Version>;
+
+/// Converts a semver::VersionReq to PubGrub Ranges.
+///
+/// This handles all semver operators: `=`, `^`, `~`, `>`, `>=`, `<`, `<=`, `*`
+pub fn version_req_to_ranges(req: &VersionReq) -> SemverRanges {
+    if req.comparators.is_empty() {
+        // Empty requirement matches everything (equivalent to `*`)
+        return Ranges::full();
+    }
+
+    // Each comparator in a VersionReq is ANDed together
+    let mut result = Ranges::full();
+
+    for comp in &req.comparators {
+        let comp_range = comparator_to_ranges(comp);
+        result = result.intersection(&comp_range);
+    }
+
+    result
+}
+
+/// Converts a single semver Comparator to PubGrub Ranges.
+fn comparator_to_ranges(comp: &Comparator) -> SemverRanges {
+    let major = comp.major;
+    let minor = comp.minor;
+    let patch = comp.patch;
+
+    match comp.op {
+        Op::Exact => {
+            // =X.Y.Z matches exactly that version
+            let version = make_version(major, minor, patch, &comp.pre);
+            Ranges::singleton(version)
+        }
+        Op::Greater => {
+            // >X.Y.Z matches versions greater than X.Y.Z
+            let version = make_version(major, minor, patch, &comp.pre);
+            // Ranges::higher_than is exclusive of the bound, so we use strictly_lower_than's complement
+            Ranges::strictly_lower_than(version.clone())
+                .complement()
+                .intersection(&Ranges::singleton(version).complement())
+        }
+        Op::GreaterEq => {
+            // >=X.Y.Z matches versions >= X.Y.Z
+            let version = make_version(major, minor, patch, &comp.pre);
+            Ranges::strictly_lower_than(version).complement()
+        }
+        Op::Less => {
+            // <X.Y.Z matches versions < X.Y.Z
+            let version = make_version(major, minor, patch, &comp.pre);
+            Ranges::strictly_lower_than(version)
+        }
+        Op::LessEq => {
+            // <=X.Y.Z matches versions <= X.Y.Z
+            let version = make_version(major, minor, patch, &comp.pre);
+            Ranges::strictly_lower_than(version.clone()).union(&Ranges::singleton(version))
+        }
+        Op::Tilde => {
+            // ~X.Y.Z matches >=X.Y.Z, <X.(Y+1).0
+            let min = make_version(major, minor, patch, &comp.pre);
+            let max = Version::new(major, minor.unwrap_or(0) + 1, 0);
+            range_between(&min, &max)
+        }
+        Op::Caret => {
+            // ^X.Y.Z - compatible updates
+            caret_range(major, minor, patch, &comp.pre)
+        }
+        Op::Wildcard => {
+            // X.* or X.Y.* - matches any version with that prefix
+            wildcard_range(major, minor)
+        }
+        _ => {
+            // Unknown operator - be permissive
+            Ranges::full()
+        }
+    }
+}
+
+/// Creates a version from components.
+fn make_version(
+    major: u64,
+    minor: Option<u64>,
+    patch: Option<u64>,
+    pre: &semver::Prerelease,
+) -> Version {
+    let mut v = Version::new(major, minor.unwrap_or(0), patch.unwrap_or(0));
+    v.pre = pre.clone();
+    v
+}
+
+/// Helper to create a range [min, max).
+fn range_between(min: &Version, max: &Version) -> SemverRanges {
+    Ranges::between(min.clone(), max.clone())
+}
+
+/// Implements caret (^) version ranges.
+///
+/// - `^1.2.3` := `>=1.2.3, <2.0.0` (major is non-zero)
+/// - `^0.2.3` := `>=0.2.3, <0.3.0` (major is zero, minor is non-zero)
+/// - `^0.0.3` := `>=0.0.3, <0.0.4` (major and minor are zero)
+fn caret_range(
+    major: u64,
+    minor: Option<u64>,
+    patch: Option<u64>,
+    pre: &semver::Prerelease,
+) -> SemverRanges {
+    let min = make_version(major, minor, patch, pre);
+
+    let max = if major > 0 {
+        Version::new(major + 1, 0, 0)
+    } else if let Some(m) = minor {
+        if m > 0 {
+            Version::new(0, m + 1, 0)
+        } else if let Some(p) = patch {
+            Version::new(0, 0, p + 1)
+        } else {
+            Version::new(0, 1, 0)
+        }
+    } else {
+        Version::new(1, 0, 0)
+    };
+
+    range_between(&min, &max)
+}
+
+/// Implements wildcard (*) version ranges.
+fn wildcard_range(major: u64, minor: Option<u64>) -> SemverRanges {
+    match minor {
+        Some(m) => {
+            // X.Y.* matches [X.Y.0, X.(Y+1).0)
+            let min = Version::new(major, m, 0);
+            let max = Version::new(major, m + 1, 0);
+            range_between(&min, &max)
+        }
+        None => {
+            // X.* matches [X.0.0, (X+1).0.0)
+            let min = Version::new(major, 0, 0);
+            let max = Version::new(major + 1, 0, 0);
+            range_between(&min, &max)
+        }
+    }
+}
+
+/// A dependency with its version requirement.
+#[derive(Debug, Clone)]
+pub struct PackageDependency {
+    /// The package name
+    pub package: PackageName,
+    /// The version requirement for this dependency
+    pub version_req: VersionReq,
+}
+
+/// Cached package information for the resolver.
+#[derive(Debug, Clone)]
+pub struct PackageInfo {
+    /// Available versions of this package
+    pub versions: Vec<Version>,
+    /// Dependencies for each version: version -> list of dependencies
+    pub dependencies: HashMap<Version, Vec<PackageDependency>>,
+}
+
+/// A dependency provider that uses pre-fetched package data.
+///
+/// This provider is populated by querying the registry for all packages
+/// before running the PubGrub resolution.
+pub struct BuffrsDependencyProvider {
+    /// Package data cache
+    packages: Arc<RwLock<HashMap<PackageName, PackageInfo>>>,
+    /// Root package dependencies
+    root_deps: Vec<PackageDependency>,
+}
+
+impl BuffrsDependencyProvider {
+    /// Creates a new dependency provider with the given root dependencies.
+    pub fn new(root_deps: Vec<PackageDependency>) -> Self {
+        Self {
+            packages: Arc::new(RwLock::new(HashMap::new())),
+            root_deps,
+        }
+    }
+
+    /// Registers package information (versions and dependencies).
+    pub fn add_package(&self, name: PackageName, info: PackageInfo) {
+        let mut packages = self.packages.write().unwrap();
+        packages.insert(name, info);
+    }
+
+    /// Gets the available versions for a package.
+    pub fn get_versions(&self, name: &PackageName) -> Option<Vec<Version>> {
+        let packages = self.packages.read().unwrap();
+        packages.get(name).map(|info| info.versions.clone())
+    }
+}
+
+impl DependencyProvider for BuffrsDependencyProvider {
+    type P = PubGrubPackage;
+    type V = Version;
+    type VS = SemverRanges;
+    type M = String;
+    type Err = Infallible;
+    type Priority = u32;
+
+    fn choose_version(
+        &self,
+        package: &Self::P,
+        range: &Self::VS,
+    ) -> Result<Option<Self::V>, Self::Err> {
+        match package {
+            PubGrubPackage::Root => {
+                // Root always has version 0.0.0
+                Ok(Some(Version::new(0, 0, 0)))
+            }
+            PubGrubPackage::Package(name) => {
+                let packages = self.packages.read().unwrap();
+                if let Some(info) = packages.get(name) {
+                    // Find the highest version that matches the range
+                    let matching = info
+                        .versions
+                        .iter()
+                        .filter(|v| range.contains(v))
+                        .max()
+                        .cloned();
+                    Ok(matching)
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    fn prioritize(
+        &self,
+        package: &Self::P,
+        range: &Self::VS,
+        _conflicts: &PackageResolutionStatistics,
+    ) -> Self::Priority {
+        // Prioritize packages with fewer matching versions
+        // This helps PubGrub fail faster on constrained packages
+        match package {
+            PubGrubPackage::Root => u32::MAX, // Always resolve root first
+            PubGrubPackage::Package(name) => {
+                let packages = self.packages.read().unwrap();
+                if let Some(info) = packages.get(name) {
+                    let count = info.versions.iter().filter(|v| range.contains(v)).count();
+                    // Fewer versions = higher priority (prioritize most constrained)
+                    u32::MAX - count as u32
+                } else {
+                    0 // Unknown package - low priority
+                }
+            }
+        }
+    }
+
+    fn get_dependencies(
+        &self,
+        package: &Self::P,
+        version: &Self::V,
+    ) -> Result<Dependencies<Self::P, Self::VS, Self::M>, Self::Err> {
+        match package {
+            PubGrubPackage::Root => {
+                // Root package dependencies
+                let mut deps = DependencyConstraints::default();
+                for dep in &self.root_deps {
+                    let range = version_req_to_ranges(&dep.version_req);
+                    deps.insert(PubGrubPackage::Package(dep.package.clone()), range);
+                }
+                Ok(Dependencies::Available(deps))
+            }
+            PubGrubPackage::Package(name) => {
+                let packages = self.packages.read().unwrap();
+                if let Some(info) = packages.get(name) {
+                    if let Some(version_deps) = info.dependencies.get(version) {
+                        let mut deps = DependencyConstraints::default();
+                        for dep in version_deps {
+                            let range = version_req_to_ranges(&dep.version_req);
+                            deps.insert(PubGrubPackage::Package(dep.package.clone()), range);
+                        }
+                        Ok(Dependencies::Available(deps))
+                    } else {
+                        // Version exists but no dependency info - assume no deps
+                        Ok(Dependencies::Available(DependencyConstraints::default()))
+                    }
+                } else {
+                    Ok(Dependencies::Unavailable(format!(
+                        "package {} not found in registry",
+                        name
+                    )))
+                }
+            }
+        }
+    }
+}
+
+/// Result of PubGrub resolution.
+pub type ResolutionResult = Result<HashMap<PackageName, Version>, ResolutionError>;
+
+/// Error returned when resolution fails.
+#[derive(Debug, Clone)]
+pub struct ResolutionError {
+    /// Human-readable explanation of why resolution failed
+    pub message: String,
+}
+
+impl fmt::Display for ResolutionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ResolutionError {}
+
+/// Runs PubGrub resolution with the given dependency provider.
+///
+/// Returns a map of package names to resolved versions.
+pub fn resolve(provider: &BuffrsDependencyProvider) -> ResolutionResult {
+    let root = PubGrubPackage::Root;
+    let root_version = Version::new(0, 0, 0);
+
+    match pubgrub::resolve(provider, root, root_version) {
+        Ok(solution) => {
+            let mut result = HashMap::new();
+            for (package, version) in solution {
+                if let PubGrubPackage::Package(name) = package {
+                    result.insert(name, version);
+                }
+            }
+            Ok(result)
+        }
+        Err(PubGrubError::NoSolution(mut derivation_tree)) => {
+            derivation_tree.collapse_no_versions();
+            let report = DefaultStringReporter::report(&derivation_tree);
+            Err(ResolutionError { message: report })
+        }
+        Err(err) => Err(ResolutionError {
+            message: format!("{:?}", err),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).unwrap()
+    }
+
+    fn req(s: &str) -> VersionReq {
+        VersionReq::parse(s).unwrap()
+    }
+
+    fn pkg(s: &str) -> PackageName {
+        PackageName::unchecked(s)
+    }
+
+    // ========================================================================
+    // Version requirement to ranges conversion tests
+    // ========================================================================
+
+    #[test]
+    fn test_version_req_to_ranges_exact() {
+        let ranges = version_req_to_ranges(&req("=1.2.3"));
+        assert!(ranges.contains(&v("1.2.3")));
+        assert!(!ranges.contains(&v("1.2.4")));
+        assert!(!ranges.contains(&v("1.2.2")));
+    }
+
+    #[test]
+    fn test_version_req_to_ranges_caret() {
+        let ranges = version_req_to_ranges(&req("^1.2.3"));
+        assert!(ranges.contains(&v("1.2.3")));
+        assert!(ranges.contains(&v("1.9.9")));
+        assert!(!ranges.contains(&v("2.0.0")));
+        assert!(!ranges.contains(&v("1.2.2")));
+    }
+
+    #[test]
+    fn test_version_req_to_ranges_caret_zero() {
+        // ^0.2.3 = >=0.2.3, <0.3.0
+        let ranges = version_req_to_ranges(&req("^0.2.3"));
+        assert!(ranges.contains(&v("0.2.3")));
+        assert!(ranges.contains(&v("0.2.9")));
+        assert!(!ranges.contains(&v("0.3.0")));
+        assert!(!ranges.contains(&v("0.2.2")));
+    }
+
+    #[test]
+    fn test_version_req_to_ranges_tilde() {
+        // ~1.2.3 = >=1.2.3, <1.3.0
+        let ranges = version_req_to_ranges(&req("~1.2.3"));
+        assert!(ranges.contains(&v("1.2.3")));
+        assert!(ranges.contains(&v("1.2.9")));
+        assert!(!ranges.contains(&v("1.3.0")));
+        assert!(!ranges.contains(&v("1.2.2")));
+    }
+
+    #[test]
+    fn test_version_req_to_ranges_greater() {
+        let ranges = version_req_to_ranges(&req(">1.0.0"));
+        assert!(!ranges.contains(&v("1.0.0")));
+        assert!(ranges.contains(&v("1.0.1")));
+        assert!(ranges.contains(&v("2.0.0")));
+    }
+
+    #[test]
+    fn test_version_req_to_ranges_greater_eq() {
+        let ranges = version_req_to_ranges(&req(">=1.0.0"));
+        assert!(ranges.contains(&v("1.0.0")));
+        assert!(ranges.contains(&v("1.0.1")));
+        assert!(!ranges.contains(&v("0.9.9")));
+    }
+
+    #[test]
+    fn test_version_req_to_ranges_less() {
+        let ranges = version_req_to_ranges(&req("<2.0.0"));
+        assert!(ranges.contains(&v("1.9.9")));
+        assert!(!ranges.contains(&v("2.0.0")));
+    }
+
+    #[test]
+    fn test_version_req_to_ranges_less_eq() {
+        let ranges = version_req_to_ranges(&req("<=2.0.0"));
+        assert!(ranges.contains(&v("2.0.0")));
+        assert!(ranges.contains(&v("1.9.9")));
+        assert!(!ranges.contains(&v("2.0.1")));
+    }
+
+    #[test]
+    fn test_version_req_to_ranges_combined() {
+        // >=1.0.0, <2.0.0
+        let ranges = version_req_to_ranges(&req(">=1.0.0, <2.0.0"));
+        assert!(ranges.contains(&v("1.0.0")));
+        assert!(ranges.contains(&v("1.5.0")));
+        assert!(!ranges.contains(&v("2.0.0")));
+        assert!(!ranges.contains(&v("0.9.0")));
+    }
+
+    #[test]
+    fn test_version_req_to_ranges_wildcard() {
+        let ranges = version_req_to_ranges(&req("*"));
+        assert!(ranges.contains(&v("0.0.0")));
+        assert!(ranges.contains(&v("999.999.999")));
+    }
+
+    // ========================================================================
+    // PubGrub resolution tests
+    // ========================================================================
+
+    #[test]
+    fn test_simple_resolution() {
+        let provider = BuffrsDependencyProvider::new(vec![PackageDependency {
+            package: pkg("foo"),
+            version_req: req("^1.0.0"),
+        }]);
+
+        provider.add_package(
+            pkg("foo"),
+            PackageInfo {
+                versions: vec![v("1.0.0"), v("1.1.0"), v("1.2.0")],
+                dependencies: HashMap::new(),
+            },
+        );
+
+        let result = resolve(&provider).unwrap();
+        assert_eq!(result.get(&pkg("foo")), Some(&v("1.2.0")));
+    }
+
+    #[test]
+    fn test_transitive_resolution() {
+        // root -> foo ^1.0.0 -> bar ^1.0.0
+        let provider = BuffrsDependencyProvider::new(vec![PackageDependency {
+            package: pkg("foo"),
+            version_req: req("^1.0.0"),
+        }]);
+
+        let mut foo_deps = HashMap::new();
+        foo_deps.insert(
+            v("1.0.0"),
+            vec![PackageDependency {
+                package: pkg("bar"),
+                version_req: req("^1.0.0"),
+            }],
+        );
+
+        provider.add_package(
+            pkg("foo"),
+            PackageInfo {
+                versions: vec![v("1.0.0")],
+                dependencies: foo_deps,
+            },
+        );
+
+        provider.add_package(
+            pkg("bar"),
+            PackageInfo {
+                versions: vec![v("1.0.0"), v("1.1.0")],
+                dependencies: HashMap::new(),
+            },
+        );
+
+        let result = resolve(&provider).unwrap();
+        assert_eq!(result.get(&pkg("foo")), Some(&v("1.0.0")));
+        assert_eq!(result.get(&pkg("bar")), Some(&v("1.1.0")));
+    }
+
+    #[test]
+    fn test_diamond_dependency_resolution() {
+        // This is the key test: diamond dependency that greedy resolution would fail
+        //
+        // root
+        // ├── A ^1.0.0
+        // │   └── C ^1.0.0 (greedy would pick C@2.0.0)
+        // └── B ^1.0.0
+        //     └── C >=1.0.0, <1.5.0 (conflict with greedy!)
+        //
+        // PubGrub should find: A@1.0.0, B@1.0.0, C@1.4.0
+
+        let provider = BuffrsDependencyProvider::new(vec![
+            PackageDependency {
+                package: pkg("A"),
+                version_req: req("^1.0.0"),
+            },
+            PackageDependency {
+                package: pkg("B"),
+                version_req: req("^1.0.0"),
+            },
+        ]);
+
+        let mut a_deps = HashMap::new();
+        a_deps.insert(
+            v("1.0.0"),
+            vec![PackageDependency {
+                package: pkg("C"),
+                version_req: req("^1.0.0"),
+            }],
+        );
+
+        let mut b_deps = HashMap::new();
+        b_deps.insert(
+            v("1.0.0"),
+            vec![PackageDependency {
+                package: pkg("C"),
+                version_req: req(">=1.0.0, <1.5.0"),
+            }],
+        );
+
+        provider.add_package(
+            pkg("A"),
+            PackageInfo {
+                versions: vec![v("1.0.0")],
+                dependencies: a_deps,
+            },
+        );
+
+        provider.add_package(
+            pkg("B"),
+            PackageInfo {
+                versions: vec![v("1.0.0")],
+                dependencies: b_deps,
+            },
+        );
+
+        provider.add_package(
+            pkg("C"),
+            PackageInfo {
+                versions: vec![v("1.0.0"), v("1.2.0"), v("1.4.0"), v("2.0.0")],
+                dependencies: HashMap::new(),
+            },
+        );
+
+        let result = resolve(&provider).unwrap();
+
+        // A and B should be resolved
+        assert_eq!(result.get(&pkg("A")), Some(&v("1.0.0")));
+        assert_eq!(result.get(&pkg("B")), Some(&v("1.0.0")));
+
+        // C should be <1.5.0 (satisfies both A's ^1.0.0 and B's >=1.0.0, <1.5.0)
+        let c_version = result.get(&pkg("C")).unwrap();
+        assert!(c_version < &v("1.5.0"));
+        assert!(c_version >= &v("1.0.0"));
+        // Should pick the highest compatible: 1.4.0
+        assert_eq!(c_version, &v("1.4.0"));
+    }
+
+    #[test]
+    fn test_unsatisfiable_dependency() {
+        // root -> foo ^1.0.0, but foo only has 2.x versions
+        let provider = BuffrsDependencyProvider::new(vec![PackageDependency {
+            package: pkg("foo"),
+            version_req: req("^1.0.0"),
+        }]);
+
+        provider.add_package(
+            pkg("foo"),
+            PackageInfo {
+                versions: vec![v("2.0.0"), v("2.1.0")],
+                dependencies: HashMap::new(),
+            },
+        );
+
+        let result = resolve(&provider);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("foo"));
+    }
+
+    #[test]
+    fn test_conflict_detection() {
+        // root -> A ^1.0.0 -> C ^2.0.0
+        // root -> B ^1.0.0 -> C ^1.0.0
+        // Both require C but with incompatible ranges
+
+        let provider = BuffrsDependencyProvider::new(vec![
+            PackageDependency {
+                package: pkg("A"),
+                version_req: req("^1.0.0"),
+            },
+            PackageDependency {
+                package: pkg("B"),
+                version_req: req("^1.0.0"),
+            },
+        ]);
+
+        let mut a_deps = HashMap::new();
+        a_deps.insert(
+            v("1.0.0"),
+            vec![PackageDependency {
+                package: pkg("C"),
+                version_req: req("^2.0.0"),
+            }],
+        );
+
+        let mut b_deps = HashMap::new();
+        b_deps.insert(
+            v("1.0.0"),
+            vec![PackageDependency {
+                package: pkg("C"),
+                version_req: req("^1.0.0"),
+            }],
+        );
+
+        provider.add_package(
+            pkg("A"),
+            PackageInfo {
+                versions: vec![v("1.0.0")],
+                dependencies: a_deps,
+            },
+        );
+
+        provider.add_package(
+            pkg("B"),
+            PackageInfo {
+                versions: vec![v("1.0.0")],
+                dependencies: b_deps,
+            },
+        );
+
+        provider.add_package(
+            pkg("C"),
+            PackageInfo {
+                versions: vec![v("1.0.0"), v("1.5.0"), v("2.0.0"), v("2.5.0")],
+                dependencies: HashMap::new(),
+            },
+        );
+
+        let result = resolve(&provider);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        // Error should mention the conflict
+        assert!(
+            err.message.contains("C") || err.message.contains("A") || err.message.contains("B")
+        );
+    }
+}

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -164,13 +164,15 @@ impl Artifactory {
             .map(|_| ())
     }
 
-    /// Retrieves the latest version of a package by querying artifactory. Returns an error if no artifact could be found
-    pub async fn get_latest_version(
+    /// Retrieves all available versions of a package from artifactory.
+    ///
+    /// Returns a list of all valid semver versions found for the package.
+    pub async fn list_versions(
         &self,
         repository: String,
         name: PackageName,
-    ) -> miette::Result<Version> {
-        // First retrieve all packages matching the given name
+    ) -> miette::Result<Vec<Version>> {
+        // Retrieve all packages matching the given name
         let search_query_url: Url = {
             let mut uri: url::Url = self.registry.to_owned().into();
             uri.set_path("artifactory/api/search/artifact");
@@ -210,8 +212,8 @@ impl Artifactory {
             parsed_response
         );
 
-        // Then from all package names retrieved from artifactory, extract the highest version number
-        let highest_version = parsed_response
+        // Extract all valid versions from the artifact URIs
+        let versions: Vec<Version> = parsed_response
             .results
             .iter()
             .filter_map(|artifact_search_result| {
@@ -220,11 +222,17 @@ impl Artifactory {
                     .split('/')
                     .next_back()
                     .map(|name_tgz| name_tgz.trim_end_matches(".tgz"));
-                let artifact_version = full_artifact_name
-                    .and_then(|name| name.split('-').next_back())
-                    .and_then(|version_str| Version::parse(version_str).ok());
+                let artifact_version = full_artifact_name.and_then(|artifact_name| {
+                    // Extract version by removing the package name prefix
+                    // Format: {name}-{version}.tgz
+                    let name_str = name.to_string();
+                    artifact_name
+                        .strip_prefix(&name_str)
+                        .and_then(|rest| rest.strip_prefix('-'))
+                        .and_then(|version_str| Version::parse(version_str).ok())
+                });
 
-                // we double check that the artifact name matches exactly
+                // Double-check that the artifact name matches exactly
                 let expected_artifact_name =
                     artifact_version.clone().map(|av| format!("{name}-{av}"));
                 if full_artifact_name.is_some_and(|actual| {
@@ -235,15 +243,83 @@ impl Artifactory {
                     None
                 }
             })
-            .max();
+            .collect();
 
-        tracing::debug!("Highest version for artifact: {:?}", highest_version);
-        highest_version.ok_or_else(|| {
+        tracing::debug!(
+            "Found {} versions for {}: {:?}",
+            versions.len(),
+            name,
+            versions
+        );
+        Ok(versions)
+    }
+
+    /// Retrieves the latest version of a package by querying artifactory. Returns an error if no artifact could be found
+    pub async fn get_latest_version(
+        &self,
+        repository: String,
+        name: PackageName,
+    ) -> miette::Result<Version> {
+        let versions = self.list_versions(repository, name.clone()).await?;
+
+        versions.into_iter().max().ok_or_else(|| {
             miette!("no version could be found on artifactory for this artifact name. Does it exist in this registry and repository?")
         })
     }
 
-    /// Downloads a package from artifactory
+    /// Downloads a package from artifactory using an already-resolved exact version.
+    ///
+    /// This is the preferred method when version resolution has already been performed.
+    pub async fn download_version(
+        &self,
+        repository: &str,
+        name: &PackageName,
+        version: &Version,
+    ) -> miette::Result<Package> {
+        use crate::version::version_to_artifact_string;
+
+        let artifact_url = {
+            let version_str = version_to_artifact_string(version);
+            let url: RegistryUri = self.registry.clone();
+            let mut url: url::Url = url.into();
+            let path = url.path();
+
+            url.set_path(&format!(
+                "{}/{}/{}/{}-{}.tgz",
+                path, repository, name, name, version_str
+            ));
+
+            url
+        };
+
+        tracing::debug!("Hitting download URL: {artifact_url}");
+
+        let response = self.new_request(Method::GET, artifact_url).send().await?;
+        let response: reqwest::Response = response.0;
+        let headers = response.headers();
+        let content_type = headers
+            .get(&reqwest::header::CONTENT_TYPE)
+            .ok_or_else(|| miette!("missing content-type header"))?;
+
+        ensure!(
+            content_type == reqwest::header::HeaderValue::from_static("application/x-gzip"),
+            "server response has incorrect mime type: {content_type:?}"
+        );
+
+        let data = response.bytes().await.into_diagnostic()?;
+
+        Package::try_from(data).wrap_err(miette!(
+            "failed to download dependency {}@{}",
+            name,
+            version
+        ))
+    }
+
+    /// Downloads a package from artifactory.
+    ///
+    /// Note: This method requires the dependency to have an exact version pinned.
+    /// For flexible version requirements, use `download_version()` after resolving
+    /// the version with `list_versions()` and `select_version()`.
     pub async fn download(&self, dependency: Dependency) -> miette::Result<Package> {
         let DependencyManifest::Remote(ref manifest) = dependency.manifest else {
             return Err(miette!(

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2,7 +2,7 @@ use async_recursion::async_recursion;
 use miette::{bail, ensure, Context, Diagnostic, IntoDiagnostic};
 use semver::{Version, VersionReq};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     env, fmt,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
@@ -36,14 +36,17 @@ pub struct ResolvedPackageId {
 }
 
 impl ResolvedPackageId {
+    /// Creates a new resolved package identifier.
     pub fn new(name: PackageName, version: Version) -> Self {
         Self { name, version }
     }
 
+    /// Returns the package name for this resolved instance.
     pub fn name(&self) -> &PackageName {
         &self.name
     }
 
+    /// Returns the resolved package version for this instance.
     pub fn version(&self) -> &Version {
         &self.version
     }
@@ -205,6 +208,7 @@ struct DownloadError {
 }
 
 impl DependencyGraph {
+    /// Creates a new dependency graph.
     pub fn new(allow_multiple_versions: bool) -> Self {
         Self {
             allow_multiple_versions,
@@ -980,9 +984,14 @@ impl<'a> DependencyGraphBuilder<'a> {
 
         // Phase 1: Collect root dependencies and discover package metadata
         let mut root_deps = Vec::new();
-        let mut remote_deps_to_discover: Vec<(PackageName, RemoteDependencyManifest)> = Vec::new();
+        let mut remote_deps_to_discover: VecDeque<(PackageName, RemoteDependencyManifest)> =
+            VecDeque::new();
         let mut local_packages: HashMap<PackageName, (Package, PathBuf, LocalDependencyManifest)> =
             HashMap::new();
+
+        // Preferred versions for reproducible installs (from Proto.lock).
+        // Applied to the PubGrub provider as a soft preference.
+        let mut preferred_versions: HashMap<PackageName, Version> = HashMap::new();
 
         for dependency in &self.manifest.dependencies {
             match &dependency.manifest {
@@ -991,7 +1000,19 @@ impl<'a> DependencyGraphBuilder<'a> {
                         package: dependency.package.clone(),
                         version_req: manifest.version.clone(),
                     });
-                    remote_deps_to_discover.push((dependency.package.clone(), manifest.clone()));
+                    remote_deps_to_discover
+                        .push_back((dependency.package.clone(), manifest.clone()));
+
+                    if let Some(locked) = self.lockfile.find(
+                        &dependency.package,
+                        &manifest.version,
+                        Some(&manifest.registry),
+                        Some(&manifest.repository),
+                    ) {
+                        preferred_versions
+                            .entry(dependency.package.clone())
+                            .or_insert_with(|| locked.version.clone());
+                    }
                 }
                 DependencyManifest::Local(manifest) => {
                     // Read local package manifest to get its version
@@ -1049,7 +1070,18 @@ impl<'a> DependencyGraphBuilder<'a> {
                     for sub_dep in &package.manifest.dependencies {
                         if let DependencyManifest::Remote(sub_manifest) = &sub_dep.manifest {
                             remote_deps_to_discover
-                                .push((sub_dep.package.clone(), sub_manifest.clone()));
+                                .push_back((sub_dep.package.clone(), sub_manifest.clone()));
+
+                            if let Some(locked) = self.lockfile.find(
+                                &sub_dep.package,
+                                &sub_manifest.version,
+                                Some(&sub_manifest.registry),
+                                Some(&sub_manifest.repository),
+                            ) {
+                                preferred_versions
+                                    .entry(sub_dep.package.clone())
+                                    .or_insert_with(|| locked.version.clone());
+                            }
                         }
                     }
 
@@ -1064,6 +1096,10 @@ impl<'a> DependencyGraphBuilder<'a> {
         // Phase 2: Discover all remote packages and their metadata
         let provider = BuffrsDependencyProvider::new(root_deps);
         let mut discovered: HashSet<PackageName> = HashSet::new();
+
+        for (name, version) in preferred_versions {
+            provider.set_preferred_version(name, version);
+        }
 
         // Add local packages to provider first (they have exactly one version)
         for (name, (package, _, _)) in &local_packages {
@@ -1109,21 +1145,28 @@ impl<'a> DependencyGraphBuilder<'a> {
 
         // Discover remote packages
         while !remote_deps_to_discover.is_empty() {
-            let (pkg_name, manifest) = remote_deps_to_discover.remove(0);
+            let (pkg_name, manifest) = remote_deps_to_discover
+                .pop_front()
+                .expect("queue is non-empty");
 
             if discovered.contains(&pkg_name) {
                 continue;
             }
             discovered.insert(pkg_name.clone());
 
+            if let Some(locked) = self.lockfile.find(
+                &pkg_name,
+                &manifest.version,
+                Some(&manifest.registry),
+                Some(&manifest.repository),
+            ) {
+                provider.set_preferred_version(pkg_name.clone(), locked.version.clone());
+            }
+
             tracing::debug!("Discovering package: {}", pkg_name);
 
             // Create registry client
-            let registry = Artifactory::new(
-                manifest.registry.clone().try_into()?,
-                self.credentials,
-                self.policy,
-            )?;
+            let registry = self.create_artifactory(manifest.registry.clone().try_into()?)?;
 
             // Get all available versions
             let versions = registry
@@ -1160,7 +1203,7 @@ impl<'a> DependencyGraphBuilder<'a> {
                                     // Add to discovery queue
                                     if !discovered.contains(&dep.package) {
                                         remote_deps_to_discover
-                                            .push((dep.package.clone(), dep_manifest.clone()));
+                                            .push_back((dep.package.clone(), dep_manifest.clone()));
                                     }
                                 }
                                 DependencyManifest::Local(dep_manifest) => {
@@ -1234,11 +1277,8 @@ impl<'a> DependencyGraphBuilder<'a> {
                     })?;
 
                     // Download the resolved version
-                    let registry = Artifactory::new(
-                        manifest.registry.clone().try_into()?,
-                        self.credentials,
-                        self.policy,
-                    )?;
+                    let registry =
+                        self.create_artifactory(manifest.registry.clone().try_into()?)?;
 
                     let package = registry
                         .download_version(
@@ -1257,13 +1297,7 @@ impl<'a> DependencyGraphBuilder<'a> {
 
                     // Process sub-dependencies recursively
                     let sub_dep_ids = self
-                        .build_pubgrub_subdeps(
-                            &package,
-                            &resolved,
-                            &local_packages,
-                            &mut deps,
-                            &parent_dir,
-                        )
+                        .build_pubgrub_subdeps(&package, &resolved, &local_packages, &mut deps)
                         .await?;
 
                     deps.insert(
@@ -1295,13 +1329,7 @@ impl<'a> DependencyGraphBuilder<'a> {
 
                     // Process sub-dependencies recursively
                     let sub_dep_ids = self
-                        .build_pubgrub_subdeps(
-                            package,
-                            &resolved,
-                            &local_packages,
-                            &mut deps,
-                            &parent_dir,
-                        )
+                        .build_pubgrub_subdeps(package, &resolved, &local_packages, &mut deps)
                         .await?;
 
                     // Extract multiversion settings
@@ -1348,7 +1376,6 @@ impl<'a> DependencyGraphBuilder<'a> {
         resolved: &HashMap<PackageName, Version>,
         local_packages: &HashMap<PackageName, (Package, PathBuf, LocalDependencyManifest)>,
         deps: &mut DependencyGraph,
-        parent_dir: &Path,
     ) -> miette::Result<Vec<ResolvedPackageId>> {
         let mut sub_dep_ids = Vec::new();
 
@@ -1380,11 +1407,8 @@ impl<'a> DependencyGraphBuilder<'a> {
                     }
 
                     // Download the resolved version
-                    let registry = Artifactory::new(
-                        manifest.registry.clone().try_into()?,
-                        self.credentials,
-                        self.policy,
-                    )?;
+                    let registry =
+                        self.create_artifactory(manifest.registry.clone().try_into()?)?;
 
                     let sub_package = registry
                         .download_version(&manifest.repository, &sub_dep.package, resolved_version)
@@ -1396,13 +1420,7 @@ impl<'a> DependencyGraphBuilder<'a> {
 
                     // Recursively process its dependencies
                     let nested_ids = self
-                        .build_pubgrub_subdeps(
-                            &sub_package,
-                            resolved,
-                            local_packages,
-                            deps,
-                            parent_dir,
-                        )
+                        .build_pubgrub_subdeps(&sub_package, resolved, local_packages, deps)
                         .await?;
 
                     deps.insert(
@@ -1461,13 +1479,7 @@ impl<'a> DependencyGraphBuilder<'a> {
 
                         // Recursively process its dependencies
                         let nested_ids = self
-                            .build_pubgrub_subdeps(
-                                local_pkg,
-                                resolved,
-                                local_packages,
-                                deps,
-                                parent_dir,
-                            )
+                            .build_pubgrub_subdeps(local_pkg, resolved, local_packages, deps)
                             .await?;
 
                         let allows_multiversion = manifest

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2,7 +2,7 @@ use async_recursion::async_recursion;
 use miette::{bail, ensure, Context, Diagnostic, IntoDiagnostic};
 use semver::{Version, VersionReq};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     env, fmt,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
@@ -19,7 +19,9 @@ use crate::{
         RemoteDependencyManifest, ResolverMode, MANIFEST_FILE,
     },
     package::{Package, PackageName, PackageStore},
+    pubgrub_resolver::{BuffrsDependencyProvider, PackageDependency, PackageInfo},
     registry::{Artifactory, CertValidationPolicy, RegistryRef, RegistryUri},
+    version::{extract_exact_version, is_exact_requirement, select_version},
 };
 
 /// Uniquely identifies a resolved package instance.
@@ -392,6 +394,16 @@ impl<'a> DependencyGraphBuilder<'a> {
 
     /// Builds the dependency graph
     pub async fn build(self) -> miette::Result<DependencyGraph> {
+        if self.config.use_greedy_resolver() {
+            tracing::info!("Using legacy greedy resolver (use_greedy_resolver=true)");
+            self.build_greedy().await
+        } else {
+            self.build_with_pubgrub().await
+        }
+    }
+
+    /// Builds the dependency graph using greedy version selection (original algorithm)
+    async fn build_greedy(self) -> miette::Result<DependencyGraph> {
         let name = self
             .manifest
             .package
@@ -777,9 +789,12 @@ impl<'a> DependencyGraphBuilder<'a> {
         dependency: RemoteDependency,
         is_root: bool,
     ) -> miette::Result<Package> {
+        let version_req = &dependency.manifest.version;
+
+        // Check if we have a locked version that matches
         if let Some(local_locked) = self.lockfile.find(
             &dependency.package,
-            &dependency.manifest.version,
+            version_req,
             Some(&dependency.manifest.registry),
             Some(&dependency.manifest.repository),
         ) {
@@ -791,16 +806,15 @@ impl<'a> DependencyGraphBuilder<'a> {
                     local_locked.registry,
             );
 
-            // For now we should only check cache if locked package matches manifest,
-            // but theoretically we should be able to still look into cache when freshly installing
-            // a dependency.
-            if dependency.manifest.version.matches(&local_locked.version) {
+            // Check cache if locked package matches manifest
+            if version_req.matches(&local_locked.version) {
                 if let Some(cached) = self.cache.get(local_locked.try_into()?).await? {
                     local_locked.validate(&cached)?;
                     return Ok(cached);
                 }
             }
 
+            // Download the locked version
             let registry = self
                 .create_artifactory(dependency.manifest.registry.clone().try_into()?)
                 .wrap_err(DownloadError {
@@ -809,13 +823,15 @@ impl<'a> DependencyGraphBuilder<'a> {
                 })?;
 
             let package = registry
-                // TODO(#205): This works now because buffrs only supports pinned versions.
-                // This logic has to change once we implement dynamic version resolution.
-                .download(dependency.clone().into())
+                .download_version(
+                    &dependency.manifest.repository,
+                    &dependency.package,
+                    &local_locked.version,
+                )
                 .await
                 .wrap_err(DownloadError {
-                    name: dependency.package,
-                    version: dependency.manifest.version,
+                    name: dependency.package.clone(),
+                    version: dependency.manifest.version.clone(),
                 })?;
 
             let file_requirement = FileRequirement::try_from(local_locked)?;
@@ -827,7 +843,7 @@ impl<'a> DependencyGraphBuilder<'a> {
             Ok(package)
         } else {
             // Package not present in lockfile (and thus not in cache)
-            // => download it from the registry
+            // => resolve version and download from the registry
             let registry = self
                 .create_artifactory(dependency.manifest.registry.clone().try_into()?)
                 .wrap_err(DownloadError {
@@ -835,12 +851,32 @@ impl<'a> DependencyGraphBuilder<'a> {
                     version: dependency.manifest.version.clone(),
                 })?;
 
-            let package = registry
-                .download(dependency.clone().into())
+            // Resolve version requirement to exact version
+            let resolved_version = self
+                .resolve_version(&registry, &dependency)
                 .await
                 .wrap_err(DownloadError {
-                    name: dependency.package,
-                    version: dependency.manifest.version,
+                    name: dependency.package.clone(),
+                    version: dependency.manifest.version.clone(),
+                })?;
+
+            tracing::debug!(
+                "Resolved {}@{} to version {}",
+                dependency.package,
+                version_req,
+                resolved_version
+            );
+
+            let package = registry
+                .download_version(
+                    &dependency.manifest.repository,
+                    &dependency.package,
+                    &resolved_version,
+                )
+                .await
+                .wrap_err(DownloadError {
+                    name: dependency.package.clone(),
+                    version: dependency.manifest.version.clone(),
                 })?;
 
             let key = Entry::from(&package);
@@ -849,5 +885,630 @@ impl<'a> DependencyGraphBuilder<'a> {
 
             Ok(package)
         }
+    }
+
+    /// Resolves a version requirement to a specific version.
+    ///
+    /// If the requirement is already exact, extracts it directly.
+    /// Otherwise, queries the registry for available versions and selects the best match.
+    async fn resolve_version(
+        &self,
+        registry: &Artifactory,
+        dependency: &RemoteDependency,
+    ) -> miette::Result<Version> {
+        let version_req = &dependency.manifest.version;
+
+        // Fast path: if version requirement is already exact, extract it
+        if is_exact_requirement(version_req) {
+            if let Some(exact) = extract_exact_version(version_req) {
+                return Ok(exact);
+            }
+        }
+
+        // Query registry for available versions
+        let available = registry
+            .list_versions(
+                dependency.manifest.repository.clone(),
+                dependency.package.clone(),
+            )
+            .await?;
+
+        if available.is_empty() {
+            miette::bail!(
+                "no versions of {} found in repository {}",
+                dependency.package,
+                dependency.manifest.repository
+            );
+        }
+
+        // Select best matching version
+        select_version(version_req, &available).ok_or_else(|| {
+            miette::miette!(
+                "no version of {} matches requirement '{}' (available: {})",
+                dependency.package,
+                version_req,
+                available
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })
+    }
+
+    /// Builds the dependency graph using PubGrub SAT-based resolution.
+    ///
+    /// This method uses a three-phase approach:
+    /// 1. Discovery: Fetch all package metadata from registries (and local manifests)
+    /// 2. Resolution: Run PubGrub to find consistent versions
+    /// 3. Download: Download packages with resolved versions
+    ///
+    /// Note: Falls back to greedy resolution when multiversion is required,
+    /// since PubGrub inherently produces single-version solutions.
+    async fn build_with_pubgrub(self) -> miette::Result<DependencyGraph> {
+        // Check if any dependency has multiversion enabled - if so, use greedy
+        // PubGrub produces single-version solutions per package, but multiversion
+        // allows multiple versions of the same package in the dependency tree
+        let has_multiversion = self
+            .manifest
+            .dependencies
+            .iter()
+            .any(|dep| match &dep.manifest {
+                DependencyManifest::Remote(m) => matches!(m.resolver, ResolverMode::MultiVersion),
+                DependencyManifest::Local(m) => m
+                    .publish
+                    .as_ref()
+                    .map(|p| matches!(p.resolver, ResolverMode::MultiVersion))
+                    .unwrap_or(false),
+            });
+
+        if has_multiversion {
+            tracing::debug!("Multiversion dependency detected - using greedy resolution");
+            return self.build_greedy().await;
+        }
+
+        tracing::debug!("Using PubGrub SAT-based resolution");
+
+        let root_name = self
+            .manifest
+            .package
+            .as_ref()
+            .map(|p| p.name.clone())
+            .unwrap_or_else(|| PackageName::unchecked("."));
+
+        let parent_dir = env::current_dir().into_diagnostic()?;
+
+        // Phase 1: Collect root dependencies and discover package metadata
+        let mut root_deps = Vec::new();
+        let mut remote_deps_to_discover: Vec<(PackageName, RemoteDependencyManifest)> = Vec::new();
+        let mut local_packages: HashMap<PackageName, (Package, PathBuf, LocalDependencyManifest)> =
+            HashMap::new();
+
+        for dependency in &self.manifest.dependencies {
+            match &dependency.manifest {
+                DependencyManifest::Remote(manifest) => {
+                    root_deps.push(PackageDependency {
+                        package: dependency.package.clone(),
+                        version_req: manifest.version.clone(),
+                    });
+                    remote_deps_to_discover.push((dependency.package.clone(), manifest.clone()));
+                }
+                DependencyManifest::Local(manifest) => {
+                    // Read local package manifest to get its version
+                    let abs_manifest_dir = if manifest.path.is_relative() {
+                        parent_dir
+                            .join(&manifest.path)
+                            .canonicalize()
+                            .into_diagnostic()
+                            .wrap_err(miette::miette!(
+                                "local dependency {} not found at path {}",
+                                dependency.package,
+                                parent_dir.join(&manifest.path).display()
+                            ))?
+                    } else {
+                        manifest.path.clone()
+                    };
+
+                    let local_manifest = Manifest::try_read_from(
+                        &abs_manifest_dir.join(MANIFEST_FILE),
+                        Some(self.config),
+                    )
+                    .await?
+                    .ok_or_else(|| {
+                        miette::miette!(
+                            "no `{}` for local package {} found at path {}",
+                            MANIFEST_FILE,
+                            dependency.package,
+                            abs_manifest_dir.join(MANIFEST_FILE).display()
+                        )
+                    })?;
+
+                    // Build the local package
+                    let store = PackageStore::open(&abs_manifest_dir).await?;
+                    let mut temp_deps = DependencyGraph::new(self.config.allow_multiple_versions());
+                    let package = store
+                        .release(&local_manifest, self.config, Some(&mut temp_deps))
+                        .await?;
+
+                    let version = package.version().clone();
+
+                    // Add version requirement for this local dep (exact version it provides)
+                    let version_req = if let Some(publish) = &manifest.publish {
+                        publish.version.clone()
+                    } else {
+                        // If no version specified, create exact requirement
+                        VersionReq::parse(&format!("={}", version)).unwrap()
+                    };
+
+                    root_deps.push(PackageDependency {
+                        package: dependency.package.clone(),
+                        version_req: version_req.clone(),
+                    });
+
+                    // Queue its remote sub-dependencies for discovery
+                    for sub_dep in &package.manifest.dependencies {
+                        if let DependencyManifest::Remote(sub_manifest) = &sub_dep.manifest {
+                            remote_deps_to_discover
+                                .push((sub_dep.package.clone(), sub_manifest.clone()));
+                        }
+                    }
+
+                    local_packages.insert(
+                        dependency.package.clone(),
+                        (package, abs_manifest_dir, manifest.clone()),
+                    );
+                }
+            }
+        }
+
+        // Phase 2: Discover all remote packages and their metadata
+        let provider = BuffrsDependencyProvider::new(root_deps);
+        let mut discovered: HashSet<PackageName> = HashSet::new();
+
+        // Add local packages to provider first (they have exactly one version)
+        for (name, (package, _, _)) in &local_packages {
+            let version = package.version().clone();
+
+            // Collect dependencies from local package
+            let mut pkg_deps = Vec::new();
+            for dep in &package.manifest.dependencies {
+                match &dep.manifest {
+                    DependencyManifest::Remote(dep_manifest) => {
+                        pkg_deps.push(PackageDependency {
+                            package: dep.package.clone(),
+                            version_req: dep_manifest.version.clone(),
+                        });
+                    }
+                    DependencyManifest::Local(dep_manifest) => {
+                        // Local sub-dep: use exact version from manifest or star
+                        let sub_version_req = dep_manifest
+                            .publish
+                            .as_ref()
+                            .map(|p| p.version.clone())
+                            .unwrap_or(VersionReq::STAR);
+                        pkg_deps.push(PackageDependency {
+                            package: dep.package.clone(),
+                            version_req: sub_version_req,
+                        });
+                    }
+                }
+            }
+
+            let mut dependencies_map = HashMap::new();
+            dependencies_map.insert(version.clone(), pkg_deps);
+
+            provider.add_package(
+                name.clone(),
+                PackageInfo {
+                    versions: vec![version],
+                    dependencies: dependencies_map,
+                },
+            );
+            discovered.insert(name.clone());
+        }
+
+        // Discover remote packages
+        while !remote_deps_to_discover.is_empty() {
+            let (pkg_name, manifest) = remote_deps_to_discover.remove(0);
+
+            if discovered.contains(&pkg_name) {
+                continue;
+            }
+            discovered.insert(pkg_name.clone());
+
+            tracing::debug!("Discovering package: {}", pkg_name);
+
+            // Create registry client
+            let registry = Artifactory::new(
+                manifest.registry.clone().try_into()?,
+                self.credentials,
+                self.policy,
+            )?;
+
+            // Get all available versions
+            let versions = registry
+                .list_versions(manifest.repository.clone(), pkg_name.clone())
+                .await?;
+
+            if versions.is_empty() {
+                miette::bail!(
+                    "no versions of {} found in repository {}",
+                    pkg_name,
+                    manifest.repository
+                );
+            }
+
+            // Fetch dependencies for each version
+            let mut dependencies_map: HashMap<Version, Vec<PackageDependency>> = HashMap::new();
+
+            for version in &versions {
+                // Download package to get its manifest
+                match registry
+                    .download_version(&manifest.repository, &pkg_name, version)
+                    .await
+                {
+                    Ok(package) => {
+                        let mut pkg_deps = Vec::new();
+                        for dep in &package.manifest.dependencies {
+                            match &dep.manifest {
+                                DependencyManifest::Remote(dep_manifest) => {
+                                    pkg_deps.push(PackageDependency {
+                                        package: dep.package.clone(),
+                                        version_req: dep_manifest.version.clone(),
+                                    });
+
+                                    // Add to discovery queue
+                                    if !discovered.contains(&dep.package) {
+                                        remote_deps_to_discover
+                                            .push((dep.package.clone(), dep_manifest.clone()));
+                                    }
+                                }
+                                DependencyManifest::Local(dep_manifest) => {
+                                    // Remote package has local dep - use version from manifest
+                                    let sub_version_req = dep_manifest
+                                        .publish
+                                        .as_ref()
+                                        .map(|p| p.version.clone())
+                                        .unwrap_or(VersionReq::STAR);
+                                    pkg_deps.push(PackageDependency {
+                                        package: dep.package.clone(),
+                                        version_req: sub_version_req,
+                                    });
+                                }
+                            }
+                        }
+                        dependencies_map.insert(version.clone(), pkg_deps);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to fetch {}@{}: {} - skipping version",
+                            pkg_name,
+                            version,
+                            e
+                        );
+                    }
+                }
+            }
+
+            provider.add_package(
+                pkg_name,
+                PackageInfo {
+                    versions: versions.clone(),
+                    dependencies: dependencies_map,
+                },
+            );
+        }
+
+        // Phase 3: Run PubGrub resolution
+        tracing::debug!(
+            "Running PubGrub resolution on {} packages...",
+            discovered.len()
+        );
+
+        let resolved = crate::pubgrub_resolver::resolve(&provider)
+            .map_err(|e| miette::miette!("dependency resolution failed:\n{}", e.message))?;
+
+        tracing::debug!(
+            "Resolved {} packages: {}",
+            resolved.len(),
+            resolved
+                .iter()
+                .map(|(name, version)| format!("{}@{}", name, version))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+
+        // Phase 4: Build dependency graph with resolved versions
+        let mut deps = DependencyGraph::new(self.config.allow_multiple_versions());
+        let mut roots = Vec::new();
+
+        for dependency in &self.manifest.dependencies {
+            match &dependency.manifest {
+                DependencyManifest::Remote(manifest) => {
+                    // Get the resolved version
+                    let resolved_version = resolved.get(&dependency.package).ok_or_else(|| {
+                        miette::miette!(
+                            "PubGrub did not resolve version for {}",
+                            dependency.package
+                        )
+                    })?;
+
+                    // Download the resolved version
+                    let registry = Artifactory::new(
+                        manifest.registry.clone().try_into()?,
+                        self.credentials,
+                        self.policy,
+                    )?;
+
+                    let package = registry
+                        .download_version(
+                            &manifest.repository,
+                            &dependency.package,
+                            resolved_version,
+                        )
+                        .await?;
+
+                    // Cache the package
+                    let key = Entry::from(&package);
+                    self.cache.put(key, package.tgz.clone()).await.ok();
+
+                    let dependency_id =
+                        ResolvedPackageId::new(package.name().clone(), package.version().clone());
+
+                    // Process sub-dependencies recursively
+                    let sub_dep_ids = self
+                        .build_pubgrub_subdeps(
+                            &package,
+                            &resolved,
+                            &local_packages,
+                            &mut deps,
+                            &parent_dir,
+                        )
+                        .await?;
+
+                    deps.insert(
+                        dependency_id.clone(),
+                        ResolvedDependency::Remote {
+                            package,
+                            registry: manifest.registry.clone(),
+                            repository: manifest.repository.clone(),
+                            dependants: vec![Dependant {
+                                name: root_name.clone(),
+                                version_req: manifest.version.clone(),
+                                allows_multiversion: matches!(
+                                    manifest.resolver,
+                                    ResolverMode::MultiVersion
+                                ),
+                                namespace_overlap_policy: manifest.namespace_overlap,
+                            }],
+                            depends_on: sub_dep_ids,
+                        },
+                    );
+
+                    roots.push(dependency_id);
+                }
+                DependencyManifest::Local(manifest) => {
+                    let (package, abs_path, _) = local_packages.get(&dependency.package).unwrap();
+
+                    let dependency_id =
+                        ResolvedPackageId::new(package.name().clone(), package.version().clone());
+
+                    // Process sub-dependencies recursively
+                    let sub_dep_ids = self
+                        .build_pubgrub_subdeps(
+                            package,
+                            &resolved,
+                            &local_packages,
+                            &mut deps,
+                            &parent_dir,
+                        )
+                        .await?;
+
+                    // Extract multiversion settings
+                    let allows_multiversion = manifest
+                        .publish
+                        .as_ref()
+                        .map(|p| matches!(p.resolver, ResolverMode::MultiVersion))
+                        .unwrap_or(false);
+                    let namespace_overlap_policy = manifest
+                        .publish
+                        .as_ref()
+                        .map(|p| p.namespace_overlap)
+                        .unwrap_or_default();
+
+                    deps.insert(
+                        dependency_id.clone(),
+                        ResolvedDependency::Local {
+                            package: package.clone(),
+                            path: abs_path.clone(),
+                            dependants: vec![Dependant {
+                                name: root_name.clone(),
+                                version_req: VersionReq::STAR,
+                                allows_multiversion,
+                                namespace_overlap_policy,
+                            }],
+                            depends_on: sub_dep_ids,
+                        },
+                    );
+
+                    roots.push(dependency_id);
+                }
+            }
+        }
+
+        deps.roots = roots;
+        Ok(deps)
+    }
+
+    /// Recursively builds sub-dependencies using pre-resolved versions from PubGrub.
+    #[async_recursion]
+    async fn build_pubgrub_subdeps(
+        &self,
+        package: &Package,
+        resolved: &HashMap<PackageName, Version>,
+        local_packages: &HashMap<PackageName, (Package, PathBuf, LocalDependencyManifest)>,
+        deps: &mut DependencyGraph,
+        parent_dir: &Path,
+    ) -> miette::Result<Vec<ResolvedPackageId>> {
+        let mut sub_dep_ids = Vec::new();
+
+        for sub_dep in &package.manifest.dependencies {
+            match &sub_dep.manifest {
+                DependencyManifest::Remote(manifest) => {
+                    let resolved_version = resolved.get(&sub_dep.package).ok_or_else(|| {
+                        miette::miette!("PubGrub did not resolve version for {}", sub_dep.package)
+                    })?;
+
+                    let dep_id =
+                        ResolvedPackageId::new(sub_dep.package.clone(), resolved_version.clone());
+
+                    // Check if already processed
+                    if let Some(existing) = deps.get_mut(&dep_id) {
+                        if let ResolvedDependency::Remote { dependants, .. } = existing {
+                            dependants.push(Dependant {
+                                name: package.name().clone(),
+                                version_req: manifest.version.clone(),
+                                allows_multiversion: matches!(
+                                    manifest.resolver,
+                                    ResolverMode::MultiVersion
+                                ),
+                                namespace_overlap_policy: manifest.namespace_overlap,
+                            });
+                        }
+                        sub_dep_ids.push(dep_id);
+                        continue;
+                    }
+
+                    // Download the resolved version
+                    let registry = Artifactory::new(
+                        manifest.registry.clone().try_into()?,
+                        self.credentials,
+                        self.policy,
+                    )?;
+
+                    let sub_package = registry
+                        .download_version(&manifest.repository, &sub_dep.package, resolved_version)
+                        .await?;
+
+                    // Cache it
+                    let key = Entry::from(&sub_package);
+                    self.cache.put(key, sub_package.tgz.clone()).await.ok();
+
+                    // Recursively process its dependencies
+                    let nested_ids = self
+                        .build_pubgrub_subdeps(
+                            &sub_package,
+                            resolved,
+                            local_packages,
+                            deps,
+                            parent_dir,
+                        )
+                        .await?;
+
+                    deps.insert(
+                        dep_id.clone(),
+                        ResolvedDependency::Remote {
+                            package: sub_package,
+                            registry: manifest.registry.clone(),
+                            repository: manifest.repository.clone(),
+                            dependants: vec![Dependant {
+                                name: package.name().clone(),
+                                version_req: manifest.version.clone(),
+                                allows_multiversion: matches!(
+                                    manifest.resolver,
+                                    ResolverMode::MultiVersion
+                                ),
+                                namespace_overlap_policy: manifest.namespace_overlap,
+                            }],
+                            depends_on: nested_ids,
+                        },
+                    );
+
+                    sub_dep_ids.push(dep_id);
+                }
+                DependencyManifest::Local(manifest) => {
+                    // Check if this local dep was discovered
+                    if let Some((local_pkg, local_path, _)) = local_packages.get(&sub_dep.package) {
+                        let dep_id = ResolvedPackageId::new(
+                            local_pkg.name().clone(),
+                            local_pkg.version().clone(),
+                        );
+
+                        // Check if already processed
+                        if let Some(existing) = deps.get_mut(&dep_id) {
+                            if let ResolvedDependency::Local { dependants, .. } = existing {
+                                let allows_multiversion = manifest
+                                    .publish
+                                    .as_ref()
+                                    .map(|p| matches!(p.resolver, ResolverMode::MultiVersion))
+                                    .unwrap_or(false);
+                                let namespace_overlap_policy = manifest
+                                    .publish
+                                    .as_ref()
+                                    .map(|p| p.namespace_overlap)
+                                    .unwrap_or_default();
+
+                                dependants.push(Dependant {
+                                    name: package.name().clone(),
+                                    version_req: VersionReq::STAR,
+                                    allows_multiversion,
+                                    namespace_overlap_policy,
+                                });
+                            }
+                            sub_dep_ids.push(dep_id);
+                            continue;
+                        }
+
+                        // Recursively process its dependencies
+                        let nested_ids = self
+                            .build_pubgrub_subdeps(
+                                local_pkg,
+                                resolved,
+                                local_packages,
+                                deps,
+                                parent_dir,
+                            )
+                            .await?;
+
+                        let allows_multiversion = manifest
+                            .publish
+                            .as_ref()
+                            .map(|p| matches!(p.resolver, ResolverMode::MultiVersion))
+                            .unwrap_or(false);
+                        let namespace_overlap_policy = manifest
+                            .publish
+                            .as_ref()
+                            .map(|p| p.namespace_overlap)
+                            .unwrap_or_default();
+
+                        deps.insert(
+                            dep_id.clone(),
+                            ResolvedDependency::Local {
+                                package: local_pkg.clone(),
+                                path: local_path.clone(),
+                                dependants: vec![Dependant {
+                                    name: package.name().clone(),
+                                    version_req: VersionReq::STAR,
+                                    allows_multiversion,
+                                    namespace_overlap_policy,
+                                }],
+                                depends_on: nested_ids,
+                            },
+                        );
+
+                        sub_dep_ids.push(dep_id);
+                    } else {
+                        // Local dep wasn't discovered - this is an error
+                        miette::bail!(
+                            "local dependency {} referenced by {} was not found",
+                            sub_dep.package,
+                            package.name()
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(sub_dep_ids)
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,481 @@
+// Copyright 2023 Helsing GmbH
+// Copyright 2026 Globus Medical, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Version selection and manipulation utilities.
+//!
+//! This module provides utilities for working with semantic versions and
+//! version requirements, including selecting the best matching version from
+//! a set of available versions.
+
+use semver::{Comparator, Op, Version, VersionReq};
+
+/// Selects the best matching version from a list of available versions.
+///
+/// Returns the highest version that satisfies the requirement.
+/// Pre-release versions are only matched if explicitly requested in the requirement.
+///
+/// # Arguments
+/// * `req` - The version requirement to satisfy
+/// * `available` - List of available versions to choose from
+///
+/// # Returns
+/// The highest matching version, or `None` if no version matches.
+///
+/// # Examples
+/// ```
+/// use semver::{Version, VersionReq};
+/// use buffrs::version::select_version;
+///
+/// let available = vec![
+///     Version::parse("1.0.0").unwrap(),
+///     Version::parse("1.1.0").unwrap(),
+///     Version::parse("1.2.0").unwrap(),
+///     Version::parse("2.0.0").unwrap(),
+/// ];
+///
+/// let req = VersionReq::parse("^1.0.0").unwrap();
+/// assert_eq!(select_version(&req, &available), Some(Version::parse("1.2.0").unwrap()));
+///
+/// let req = VersionReq::parse("~1.0.0").unwrap();
+/// assert_eq!(select_version(&req, &available), Some(Version::parse("1.0.0").unwrap()));
+/// ```
+pub fn select_version(req: &VersionReq, available: &[Version]) -> Option<Version> {
+    available.iter().filter(|v| req.matches(v)).max().cloned()
+}
+
+/// Checks if a version requirement specifies an exact version.
+///
+/// Returns `true` if the requirement has exactly one comparator with `Op::Exact`.
+pub fn is_exact_requirement(req: &VersionReq) -> bool {
+    req.comparators.len() == 1 && req.comparators.first().is_some_and(|c| c.op == Op::Exact)
+}
+
+/// Extracts the exact version from a requirement that specifies one.
+///
+/// Returns `None` if the requirement is not exact or is malformed.
+pub fn extract_exact_version(req: &VersionReq) -> Option<Version> {
+    if !is_exact_requirement(req) {
+        return None;
+    }
+
+    let comparator = req.comparators.first()?;
+    Some(Version {
+        major: comparator.major,
+        minor: comparator.minor.unwrap_or(0),
+        patch: comparator.patch.unwrap_or(0),
+        pre: comparator.pre.clone(),
+        build: semver::BuildMetadata::EMPTY,
+    })
+}
+
+/// Creates an exact version requirement from a version.
+pub fn to_exact_requirement(version: &Version) -> VersionReq {
+    VersionReq {
+        comparators: vec![Comparator {
+            op: Op::Exact,
+            major: version.major,
+            minor: Some(version.minor),
+            patch: Some(version.patch),
+            pre: version.pre.clone(),
+        }],
+    }
+}
+
+/// Converts a version to its artifact path string representation.
+///
+/// This is used when constructing download URLs for packages.
+pub fn version_to_artifact_string(version: &Version) -> String {
+    if version.pre.is_empty() {
+        format!("{}.{}.{}", version.major, version.minor, version.patch)
+    } else {
+        format!(
+            "{}.{}.{}-{}",
+            version.major, version.minor, version.patch, version.pre
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).unwrap()
+    }
+
+    fn req(s: &str) -> VersionReq {
+        VersionReq::parse(s).unwrap()
+    }
+
+    // ========================================================================
+    // Basic select_version tests
+    // ========================================================================
+
+    #[test]
+    fn test_select_version_caret() {
+        let available = vec![v("1.0.0"), v("1.1.0"), v("1.2.0"), v("2.0.0")];
+
+        // ^1.0.0 matches >=1.0.0, <2.0.0
+        assert_eq!(select_version(&req("^1.0.0"), &available), Some(v("1.2.0")));
+
+        // ^1.1.0 matches >=1.1.0, <2.0.0
+        assert_eq!(select_version(&req("^1.1.0"), &available), Some(v("1.2.0")));
+
+        // ^2.0.0 matches >=2.0.0, <3.0.0
+        assert_eq!(select_version(&req("^2.0.0"), &available), Some(v("2.0.0")));
+    }
+
+    #[test]
+    fn test_select_version_caret_zero_major() {
+        // Special handling for 0.x versions
+        let available = vec![v("0.1.0"), v("0.1.5"), v("0.2.0"), v("0.2.3")];
+
+        // ^0.1.0 matches >=0.1.0, <0.2.0 (minor is breaking for 0.x)
+        assert_eq!(select_version(&req("^0.1.0"), &available), Some(v("0.1.5")));
+
+        // ^0.2.0 matches >=0.2.0, <0.3.0
+        assert_eq!(select_version(&req("^0.2.0"), &available), Some(v("0.2.3")));
+    }
+
+    #[test]
+    fn test_select_version_caret_zero_minor() {
+        // Even more special handling for 0.0.x versions
+        let available = vec![v("0.0.1"), v("0.0.2"), v("0.0.3")];
+
+        // ^0.0.1 matches =0.0.1 only (patch is breaking for 0.0.x)
+        assert_eq!(select_version(&req("^0.0.1"), &available), Some(v("0.0.1")));
+    }
+
+    #[test]
+    fn test_select_version_tilde() {
+        let available = vec![v("1.0.0"), v("1.0.5"), v("1.1.0"), v("1.2.0")];
+
+        // ~1.0.0 matches >=1.0.0, <1.1.0
+        assert_eq!(select_version(&req("~1.0.0"), &available), Some(v("1.0.5")));
+
+        // ~1.1.0 matches >=1.1.0, <1.2.0
+        assert_eq!(select_version(&req("~1.1.0"), &available), Some(v("1.1.0")));
+    }
+
+    #[test]
+    fn test_select_version_exact() {
+        let available = vec![v("1.0.0"), v("1.1.0"), v("1.2.0")];
+
+        assert_eq!(select_version(&req("=1.1.0"), &available), Some(v("1.1.0")));
+        assert_eq!(select_version(&req("=1.3.0"), &available), None);
+    }
+
+    #[test]
+    fn test_select_version_ranges() {
+        let available = vec![v("1.0.0"), v("1.5.0"), v("2.0.0"), v("2.5.0")];
+
+        // >=1.0.0, <2.0.0
+        assert_eq!(
+            select_version(&req(">=1.0.0, <2.0.0"), &available),
+            Some(v("1.5.0"))
+        );
+
+        // >1.5.0
+        assert_eq!(select_version(&req(">1.5.0"), &available), Some(v("2.5.0")));
+
+        // <=1.5.0
+        assert_eq!(
+            select_version(&req("<=1.5.0"), &available),
+            Some(v("1.5.0"))
+        );
+    }
+
+    #[test]
+    fn test_select_version_complex_ranges() {
+        let available = vec![
+            v("1.0.0"),
+            v("1.2.0"),
+            v("1.5.0"),
+            v("2.0.0"),
+            v("2.1.0"),
+            v("3.0.0"),
+        ];
+
+        // Multiple disjoint ranges don't work with comma (it's AND, not OR)
+        // >=1.0.0, <1.3.0 AND >=2.0.0 would match nothing
+        // But >=1.0.0, <=2.1.0 works
+        assert_eq!(
+            select_version(&req(">=1.0.0, <=2.1.0"), &available),
+            Some(v("2.1.0"))
+        );
+
+        // Narrow range
+        assert_eq!(
+            select_version(&req(">=1.1.0, <1.6.0"), &available),
+            Some(v("1.5.0"))
+        );
+    }
+
+    #[test]
+    fn test_select_version_wildcard() {
+        let available = vec![v("1.0.0"), v("2.0.0"), v("3.0.0")];
+
+        assert_eq!(select_version(&req("*"), &available), Some(v("3.0.0")));
+    }
+
+    #[test]
+    fn test_select_version_wildcard_minor() {
+        let available = vec![v("1.0.0"), v("1.5.0"), v("1.9.0"), v("2.0.0")];
+
+        // 1.* matches any 1.x.y
+        assert_eq!(select_version(&req("1.*"), &available), Some(v("1.9.0")));
+    }
+
+    #[test]
+    fn test_select_version_wildcard_patch() {
+        let available = vec![v("1.2.0"), v("1.2.3"), v("1.2.9"), v("1.3.0")];
+
+        // 1.2.* matches any 1.2.x
+        assert_eq!(select_version(&req("1.2.*"), &available), Some(v("1.2.9")));
+    }
+
+    // ========================================================================
+    // Pre-release version tests
+    // ========================================================================
+
+    #[test]
+    fn test_select_version_prerelease() {
+        let available = vec![
+            v("1.0.0"),
+            v("1.1.0-alpha.1"),
+            v("1.1.0-beta.1"),
+            v("1.1.0"),
+        ];
+
+        // By default, pre-release versions are not matched by caret
+        assert_eq!(select_version(&req("^1.0.0"), &available), Some(v("1.1.0")));
+
+        // Explicit pre-release requirement
+        assert_eq!(
+            select_version(&req("=1.1.0-alpha.1"), &available),
+            Some(v("1.1.0-alpha.1"))
+        );
+    }
+
+    #[test]
+    fn test_select_version_prerelease_ordering() {
+        // Pre-release versions sort before their release
+        let available = vec![
+            v("1.0.0-alpha.1"),
+            v("1.0.0-alpha.2"),
+            v("1.0.0-beta.1"),
+            v("1.0.0-rc.1"),
+            v("1.0.0"),
+        ];
+
+        // Exact pre-release
+        assert_eq!(
+            select_version(&req("=1.0.0-beta.1"), &available),
+            Some(v("1.0.0-beta.1"))
+        );
+
+        // >= pre-release picks the release
+        assert_eq!(
+            select_version(&req(">=1.0.0-alpha.1"), &available),
+            Some(v("1.0.0"))
+        );
+    }
+
+    #[test]
+    fn test_select_version_prerelease_only_available() {
+        let available = vec![v("1.0.0-alpha.1"), v("1.0.0-alpha.2"), v("1.0.0-beta.1")];
+
+        // ^1.0.0 won't match pre-releases
+        assert_eq!(select_version(&req("^1.0.0"), &available), None);
+
+        // But ^1.0.0-alpha will match pre-releases starting with that prefix
+        // Actually semver crate behavior: even this won't match general prereleases
+        // We need explicit pre-release requirements
+        assert_eq!(
+            select_version(&req(">=1.0.0-alpha.1"), &available),
+            Some(v("1.0.0-beta.1"))
+        );
+    }
+
+    // ========================================================================
+    // Edge cases
+    // ========================================================================
+
+    #[test]
+    fn test_select_version_empty() {
+        let available: Vec<Version> = vec![];
+        assert_eq!(select_version(&req("^1.0.0"), &available), None);
+    }
+
+    #[test]
+    fn test_select_version_single() {
+        let available = vec![v("1.0.0")];
+        assert_eq!(select_version(&req("^1.0.0"), &available), Some(v("1.0.0")));
+        assert_eq!(select_version(&req("^2.0.0"), &available), None);
+    }
+
+    #[test]
+    fn test_select_version_no_match() {
+        let available = vec![v("1.0.0"), v("1.1.0"), v("1.2.0")];
+        assert_eq!(select_version(&req("^2.0.0"), &available), None);
+        assert_eq!(select_version(&req(">=3.0.0"), &available), None);
+    }
+
+    #[test]
+    fn test_select_version_unsorted_input() {
+        // Input doesn't need to be sorted - we find max
+        let available = vec![v("1.2.0"), v("1.0.0"), v("1.5.0"), v("1.1.0")];
+        assert_eq!(select_version(&req("^1.0.0"), &available), Some(v("1.5.0")));
+    }
+
+    #[test]
+    fn test_select_version_duplicates() {
+        let available = vec![v("1.0.0"), v("1.0.0"), v("1.1.0"), v("1.1.0")];
+        assert_eq!(select_version(&req("^1.0.0"), &available), Some(v("1.1.0")));
+    }
+
+    // ========================================================================
+    // is_exact_requirement tests
+    // ========================================================================
+
+    #[test]
+    fn test_is_exact_requirement() {
+        assert!(is_exact_requirement(&req("=1.0.0")));
+        assert!(is_exact_requirement(&req("=1.0.0-alpha")));
+        assert!(!is_exact_requirement(&req("^1.0.0")));
+        assert!(!is_exact_requirement(&req("~1.0.0")));
+        assert!(!is_exact_requirement(&req(">=1.0.0")));
+        assert!(!is_exact_requirement(&req(">=1.0.0, <2.0.0")));
+        assert!(!is_exact_requirement(&req("*")));
+    }
+
+    #[test]
+    fn test_is_exact_requirement_edge_cases() {
+        // Partial versions aren't exact in our definition
+        assert!(is_exact_requirement(&req("=1.0.0")));
+        // Build metadata
+        assert!(is_exact_requirement(&req("=1.0.0")));
+    }
+
+    // ========================================================================
+    // extract_exact_version tests
+    // ========================================================================
+
+    #[test]
+    fn test_extract_exact_version() {
+        assert_eq!(extract_exact_version(&req("=1.2.3")), Some(v("1.2.3")));
+        assert_eq!(
+            extract_exact_version(&req("=1.2.3-alpha.1")),
+            Some(v("1.2.3-alpha.1"))
+        );
+        assert_eq!(extract_exact_version(&req("^1.2.3")), None);
+        assert_eq!(extract_exact_version(&req(">=1.0.0, <2.0.0")), None);
+    }
+
+    #[test]
+    fn test_extract_exact_version_roundtrip() {
+        let version = v("1.2.3");
+        let exact_req = to_exact_requirement(&version);
+        let extracted = extract_exact_version(&exact_req);
+        assert_eq!(extracted, Some(version));
+    }
+
+    // ========================================================================
+    // to_exact_requirement tests
+    // ========================================================================
+
+    #[test]
+    fn test_to_exact_requirement() {
+        let version = v("1.2.3");
+        let exact = to_exact_requirement(&version);
+        assert!(is_exact_requirement(&exact));
+        assert!(exact.matches(&version));
+        assert!(!exact.matches(&v("1.2.4")));
+    }
+
+    #[test]
+    fn test_to_exact_requirement_prerelease() {
+        let version = v("1.2.3-beta.1");
+        let exact = to_exact_requirement(&version);
+        assert!(is_exact_requirement(&exact));
+        assert!(exact.matches(&version));
+        assert!(!exact.matches(&v("1.2.3")));
+        assert!(!exact.matches(&v("1.2.3-beta.2")));
+    }
+
+    // ========================================================================
+    // version_to_artifact_string tests
+    // ========================================================================
+
+    #[test]
+    fn test_version_to_artifact_string() {
+        assert_eq!(version_to_artifact_string(&v("1.2.3")), "1.2.3");
+        assert_eq!(
+            version_to_artifact_string(&v("1.2.3-alpha.1")),
+            "1.2.3-alpha.1"
+        );
+        assert_eq!(version_to_artifact_string(&v("0.0.1")), "0.0.1");
+    }
+
+    #[test]
+    fn test_version_to_artifact_string_edge_cases() {
+        assert_eq!(version_to_artifact_string(&v("0.0.0")), "0.0.0");
+        assert_eq!(version_to_artifact_string(&v("999.999.999")), "999.999.999");
+        assert_eq!(
+            version_to_artifact_string(&v("1.0.0-rc.1+build.123")),
+            "1.0.0-rc.1"
+        );
+    }
+
+    // ========================================================================
+    // Limitation demonstration tests
+    // These tests document known limitations of the greedy resolution approach
+    // ========================================================================
+
+    /// Demonstrates that our greedy approach always picks the highest matching version.
+    /// This can cause problems in diamond dependency scenarios.
+    ///
+    /// Example scenario (not testable in unit tests, but documented):
+    /// ```text
+    /// root
+    /// ├── A ^1.0.0 (resolves to 1.5.0)
+    /// │   └── C ^1.0.0 (C 1.5.0 chosen greedily)
+    /// └── B ^1.0.0 (resolves to 1.3.0)
+    ///     └── C ^1.2.0, <1.4.0 (CONFLICT: C 1.5.0 doesn't match!)
+    /// ```
+    ///
+    /// A SAT-based resolver (PubGrub) would find C@1.3.x that satisfies both.
+    #[test]
+    fn test_greedy_resolution_limitation_documented() {
+        // This test just documents the limitation
+        // The actual conflict happens at resolution time, not version selection time
+        let available_c = vec![v("1.0.0"), v("1.2.0"), v("1.3.0"), v("1.5.0")];
+
+        // A's constraint: ^1.0.0 -> picks 1.5.0 (greedy)
+        assert_eq!(
+            select_version(&req("^1.0.0"), &available_c),
+            Some(v("1.5.0"))
+        );
+
+        // B's constraint: >=1.2.0, <1.4.0 -> would pick 1.3.0
+        assert_eq!(
+            select_version(&req(">=1.2.0, <1.4.0"), &available_c),
+            Some(v("1.3.0"))
+        );
+
+        // The intersection exists (1.2.0, 1.3.0) but greedy picks 1.5.0 first
+        // A proper SAT solver would find 1.3.0 as the solution
+    }
+}

--- a/tests/test_registry.rs
+++ b/tests/test_registry.rs
@@ -99,10 +99,7 @@ async fn get_package(
 }
 
 /// HEAD handler: returns 200 if artifact exists, 404 otherwise (no body)
-async fn head_package(
-    extract::State(state): extract::State<State>,
-    extract::Path(path): extract::Path<String>,
-) -> StatusCode {
+async fn head_package(State(state): State<AppState>, Path(path): Path<String>) -> StatusCode {
     tracing::info!("HEAD check for {path}");
     if state.read().unwrap().contains_key(&path) {
         StatusCode::OK

--- a/tests/test_registry.rs
+++ b/tests/test_registry.rs
@@ -4,37 +4,89 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use axum::{
-    extract,
+    extract::{Extension, Path, Query, State},
     http::{header, StatusCode},
     response::IntoResponse,
     routing::get,
-    Router,
+    Json, Router,
 };
 use bytes::Bytes;
 use miette::{miette, Context as _, IntoDiagnostic};
+use serde::Serialize;
 use tokio::net::TcpListener;
 
-type State = Arc<RwLock<HashMap<String, Bytes>>>;
+type AppState = Arc<RwLock<HashMap<String, Bytes>>>;
 
 /// Run a minimal registry for local testing
-async fn test_registry(listener: TcpListener) -> miette::Result<()> {
+async fn test_registry(listener: TcpListener, base_url: String) -> miette::Result<()> {
     let state = Arc::new(RwLock::new(HashMap::<String, Bytes>::new()));
     let app = Router::new()
+        .route("/artifactory/api/search/artifact", get(search_artifacts))
         .route(
             "/*path",
             get(get_package).head(head_package).put(put_package),
         )
-        .with_state(state);
+        .with_state(state)
+        .layer(Extension(base_url));
     axum::serve(listener, app)
         .await
         .into_diagnostic()
         .wrap_err(miette!("failed to read the token from the user"))
 }
 
+/// Artifactory artifact search response format
+#[derive(Serialize)]
+struct ArtifactSearchResponse {
+    results: Vec<ArtifactSearchResult>,
+}
+
+#[derive(Serialize)]
+struct ArtifactSearchResult {
+    uri: String,
+}
+
+/// Handle Artifactory-style artifact search API
+/// GET /artifactory/api/search/artifact?name={name}&repos={repository}
+async fn search_artifacts(
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+    Extension(base_url): Extension<String>,
+) -> impl IntoResponse {
+    let name = params.get("name").cloned().unwrap_or_default();
+    let _repos = params.get("repos").cloned().unwrap_or_default();
+
+    tracing::info!("Searching for artifacts matching name: {}", name);
+
+    let state = state.read().unwrap();
+
+    // Find all packages matching the name pattern
+    let results: Vec<ArtifactSearchResult> = state
+        .keys()
+        .filter(|path| {
+            // Path format: registry/{repository}/{name}/{version}/{name}-{version}.tgz
+            // Extract the package name from the path and compare
+            path.contains(&format!("/{name}/")) || path.contains(&format!("/{name}-"))
+        })
+        .map(|path| ArtifactSearchResult {
+            uri: format!("{base_url}/{path}"),
+        })
+        .collect();
+
+    tracing::info!("Found {} matching artifacts", results.len());
+
+    (
+        [(
+            header::CONTENT_TYPE,
+            "application/vnd.org.jfrog.artifactory.search.ArtifactSearchResult+json",
+        )],
+        Json(ArtifactSearchResponse { results }),
+    )
+}
+
 // basic handler that responds with a static string
 async fn get_package(
-    extract::State(state): extract::State<State>,
-    extract::Path(path): extract::Path<String>,
+    State(state): State<AppState>,
+    Path(path): Path<String>,
 ) -> Result<impl IntoResponse, StatusCode> {
     tracing::info!("Downloaded package from {path}");
     let content = state
@@ -59,11 +111,7 @@ async fn head_package(
     }
 }
 
-async fn put_package(
-    extract::State(state): extract::State<State>,
-    extract::Path(path): extract::Path<String>,
-    body: Bytes,
-) {
+async fn put_package(State(state): State<AppState>, Path(path): Path<String>, body: Bytes) {
     tracing::info!("Uploaded package to {path} ({} bytes)", body.len());
     state.write().unwrap().insert(path, body);
 }
@@ -75,10 +123,11 @@ pub async fn with_test_registry<F: FnOnce(&str)>(f: F) {
     let listen = SocketAddr::new("127.0.0.1".parse().unwrap(), 0);
     let listener = TcpListener::bind(listen).await.unwrap();
     let local_addr = listener.local_addr().unwrap();
-    let handle = tokio::task::spawn(test_registry(listener));
+    let base_url = format!("http://{local_addr}");
+    let handle = tokio::task::spawn(test_registry(listener, base_url.clone()));
 
     tracing::info!("Listening on {local_addr:?}");
-    let url = format!("http://{local_addr}/registry");
+    let url = format!("{base_url}/registry");
 
     // wait until the test registry is ready
     let dur = Duration::from_millis(10);


### PR DESCRIPTION
## Summary

This PR implements full semver support with PubGrub SAT-based dependency resolution, addressing #16.

> **Note**: This PR is rebased on top of PR #15 (multi-version support) and should be merged after it.

## Changes

### New Files
- **`src/pubgrub_resolver.rs`**: PubGrub `DependencyProvider` implementation with:
  - `BuffrsDependencyProvider` for package discovery
  - `version_req_to_ranges()` converting semver to PubGrub ranges
  - Full support for `^`, `~`, `=`, `>`, `>=`, `<`, `<=`, `*` operators
  - 15 unit tests including diamond dependency scenarios

- **`src/version.rs`**: Greedy version selection utilities with 27 unit tests

- **`docs/semver-support-plan.md`**: Implementation plan document

### Modified Files
- **`src/resolver.rs`**: 
  - `build_with_pubgrub()` with three-phase resolution: discover → resolve → download
  - Full local dependency support
  - Falls back to greedy when `resolver = "multiversion"` is specified
  
- **`src/config.rs`**: Changed `use_pubgrub` → `use_greedy_resolver` (PubGrub is now default)

- **`src/registry/artifactory.rs`**: Added `list_versions()` API

- **`src/main.rs`**: Added `EnvFilter` to suppress pubgrub debug output (configurable via `BUFFRS_LOG`)

- **`Cargo.toml`**: Added pubgrub crate, env-filter feature, axum query/json features

- **`tests/test_registry.rs`**: Added Artifactory `/api/search/artifact` endpoint

## Design Decisions

1. **PubGrub is default**: No opt-in flag required, matching Cargo's approach
2. **Multiversion fallback**: PubGrub produces single-version solutions, so multiversion scenarios use greedy resolution
3. **Local dependencies**: Fully supported as single-version packages in PubGrub

## Testing

- 113 tests pass (91 lib + 20 e2e + 2 registry)
- 42 new tests (27 version selection + 15 PubGrub)

## Dependencies

- Requires PR #15 to be merged first

## Issues Resolved

- Closes #16 - Enable full semantic versioning (PubGrub resolver)
- Closes #17 - buf.yml STANDARD lint rule (already using STANDARD in default template)
- Closes #19 - Registry TLS/certs: custom CA bundle via `BUFFRS_CA_BUNDLE` env var
- Closes #20 - Connection pool sharing via `Artifactory::new_with_client()` API
- Closes #21 - Security/deps: `cargo deny` passes cleanly
- Closes #22 - Publish: skip upload if artifact already exists (idempotent publish)
- Closes #23 - Manifest: allow Proto.toml without [dependencies] section