### PR TITLE
refactor(namespace_scan): use regex instead of byte-based loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,9 +344,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -310,6 +310,7 @@ dependencies = [
  "protobuf-parse",
  "protoc-bin-vendored",
  "pubgrub",
+ "regex",
  "reqwest",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 description = "Modern protobuf package management"
 authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "Modern protobuf package management"
 authors = [
@@ -55,6 +55,7 @@ protobuf-parse = { version = "3.3.0", optional = true }
 pubgrub = "0.3"
 reqwest = { version = "0.12", features = ["rustls-tls-native-roots"], default-features = false }
 semver = { version = "1", features = ["serde"] }
+regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/src/config.rs
+++ b/src/config.rs
@@ -224,25 +224,33 @@ impl Config {
         let config = Self::parse_config(config_path)?;
 
         // Load edition from root of the config file
-        let edition = config
+        let edition: Edition = config
             .get("edition")
             .and_then(|edition| edition.as_str())
             .ok_or_else(|| miette!("missing or invalid 'edition' field in config file"))?
             .into();
 
-        match edition {
-            Edition::Canary => (),
-            _ => bail!("unsupported config file edition, supported editions: {CANARY_EDITION}"),
+        // Reject unknown editions; accept all known editions with version-appropriate parsing
+        if edition == Edition::Unknown {
+            let edition_str = config
+                .get("edition")
+                .and_then(|e| e.as_str())
+                .unwrap_or("<invalid>");
+            bail!(
+                "unsupported config file edition '{}', supported editions: 0.7, 0.8, 0.9, 0.10, {}",
+                edition_str,
+                CANARY_EDITION
+            );
         }
 
-        // Load registries from [registries] section
+        // Load registries from [registries] section (supported in all editions)
         let registries = Self::get_registries(&config, config_path)?;
 
-        // Locate default registry from [registry.default]
+        // Locate default registry from [registry.default] (supported in all editions)
         let default_registry = Self::get_default_registry(&config, &registries)?;
 
-        // Parse resolver settings
-        let resolver = Self::get_resolver_config(&config);
+        // Parse resolver settings only for edition 0.50+; older editions use defaults
+        let resolver = Self::get_resolver_config_for_edition(&config, &edition, config_path)?;
 
         // Parse command-specific default arguments from [commands.*] sections
         // (takes ownership of config)
@@ -258,7 +266,49 @@ impl Config {
         })
     }
 
-    fn get_resolver_config(config: &toml::Value) -> ResolverConfig {
+    /// Parse resolver config with edition-aware behavior.
+    ///
+    /// - Edition 0.50 (Canary): full [resolver] section support
+    /// - Editions 0.7-0.10: no [resolver] support; warn if present, use legacy defaults
+    fn get_resolver_config_for_edition(
+        config: &toml::Value,
+        edition: &Edition,
+        config_path: &Path,
+    ) -> miette::Result<ResolverConfig> {
+        let has_resolver_section = config.get("resolver").is_some();
+
+        match edition {
+            Edition::Canary => {
+                // Edition 0.50: parse [resolver] section if present
+                Ok(Self::parse_resolver_section(config))
+            }
+            Edition::Canary10 | Edition::Canary09 | Edition::Canary08 | Edition::Canary07 => {
+                // Older editions: [resolver] section not supported
+                if has_resolver_section {
+                    bail!(
+                        "[resolver] section is not supported in config edition '{}'; \
+                         upgrade to edition = \"{}\" in {}",
+                        <&str>::from(edition.clone()),
+                        CANARY_EDITION,
+                        config_path.display()
+                    );
+                }
+                // Legacy defaults: greedy resolver, no multi-version, link safety enabled
+                Ok(ResolverConfig {
+                    allow_multiple_versions: false,
+                    skip_link_safety_check: false,
+                    use_greedy_resolver: true, // pre-0.50 used greedy resolver
+                })
+            }
+            Edition::Unknown => {
+                // Should not reach here; caught earlier
+                unreachable!("unknown edition should be rejected before parsing resolver config")
+            }
+        }
+    }
+
+    /// Parse the [resolver] section from config (edition 0.50+)
+    fn parse_resolver_section(config: &toml::Value) -> ResolverConfig {
         let allow_multiple_versions = config
             .get("resolver")
             .and_then(|resolver| resolver.get("allow_multiple_versions"))
@@ -459,5 +509,93 @@ allow_multiple_versions = true
         );
 
         assert_eq!(config.allow_multiple_versions(), true);
+    }
+
+    #[test]
+    fn test_legacy_edition_010_uses_greedy_resolver() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join(CONFIG_FILE);
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        let mut file = File::create(&config_path).unwrap();
+        file.write_all(
+            br#"
+edition = "0.10"
+
+[registry]
+default = "globus"
+
+[registries]
+globus = "https://conan-us.globusmedical.com/artifactory"
+
+[commands.install]
+default_args = ["--generate-buf-yaml"]
+"#,
+        )
+        .unwrap();
+
+        let config = Config::new_from_config_file(&config_path).unwrap();
+        assert_eq!(config.edition, Edition::Canary10);
+        assert_eq!(config.default_registry, Some("globus".to_string()));
+        // Legacy editions use greedy resolver by default
+        assert!(config.use_greedy_resolver());
+        // Multi-version is disabled in legacy editions
+        assert!(!config.allow_multiple_versions());
+        // Link safety check is enabled in legacy editions
+        assert!(!config.skip_link_safety_check());
+    }
+
+    #[test]
+    fn test_legacy_edition_with_resolver_section_fails() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join(CONFIG_FILE);
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        let mut file = File::create(&config_path).unwrap();
+        file.write_all(
+            br#"
+edition = "0.10"
+
+[registries]
+globus = "https://conan-us.globusmedical.com/artifactory"
+
+[resolver]
+allow_multiple_versions = true
+"#,
+        )
+        .unwrap();
+
+        let result = Config::new_from_config_file(&config_path);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("[resolver] section is not supported"),
+            "Expected error about [resolver] not supported, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_unknown_edition_fails() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join(CONFIG_FILE);
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        let mut file = File::create(&config_path).unwrap();
+        file.write_all(
+            br#"
+edition = "99.99"
+
+[registries]
+acme = "https://conan.acme.com/artifactory"
+"#,
+        )
+        .unwrap();
+
+        let result = Config::new_from_config_file(&config_path);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("unsupported config file edition '99.99'"),
+            "Expected error about unsupported edition, got: {}",
+            err
+        );
     }
 }

--- a/src/namespace_scan.rs
+++ b/src/namespace_scan.rs
@@ -161,13 +161,14 @@ pub fn extract_proto_package(contents: &str) -> Option<String> {
 
     // Find first `package ...;` statement using regex.
     // Pattern: word boundary + "package" + whitespace + package name + optional whitespace + semicolon
-    // Package names consist of identifiers separated by dots: [a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*
-    static PACKAGE_RE: OnceLock<Regex> = OnceLock::new();
+    // Package names are parsed as: [a-zA-Z_][a-zA-Z0-9_.]* (a leading identifier char, followed by any combination of identifier chars and dots).
+    static PACKAGE_RE: OnceLock<Option<Regex>> = OnceLock::new();
     let re = PACKAGE_RE.get_or_init(|| {
-        Regex::new(r"(?m)(?:^|[^a-zA-Z0-9_])package\s+([a-zA-Z_][a-zA-Z0-9_.]*?)\s*;").unwrap()
+        Regex::new(r"(?m)(?:^|[^a-zA-Z0-9_])package\s+([a-zA-Z_][a-zA-Z0-9_.]*)\s*;").ok()
     });
 
-    re.captures(&out)
+    re.as_ref()?
+        .captures(&out)
         .and_then(|caps| caps.get(1))
         .map(|m| m.as_str().to_string())
 }
@@ -411,6 +412,18 @@ pub fn rewrite_proto_package(contents: &str, version: &Version) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_package_regex_compiles() {
+        // Ensure the hardcoded regex pattern is always valid
+        let regex =
+            regex::Regex::new(r"(?m)(?:^|[^a-zA-Z0-9_])package\s+([a-zA-Z_][a-zA-Z0-9_.]*)\s*;");
+        assert!(
+            regex.is_ok(),
+            "Package regex pattern should always compile: {:?}",
+            regex.err()
+        );
+    }
 
     #[test]
     fn test_extract_proto_package_simple() {

--- a/src/namespace_scan.rs
+++ b/src/namespace_scan.rs
@@ -28,8 +28,10 @@
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::OnceLock;
 
 use miette::{miette, IntoDiagnostic};
+use regex::Regex;
 use semver::Version;
 use sha2::{Digest as Sha2Digest, Sha256};
 use tokio::fs;
@@ -157,47 +159,17 @@ pub fn extract_proto_package(contents: &str) -> Option<String> {
         out.push(c);
     }
 
-    // Find first `package ...;` statement.
-    let bytes = out.as_bytes();
-    let mut i = 0;
-    while i + 7 <= bytes.len() {
-        // look for "package" keyword
-        if &bytes[i..i + 7] == b"package" {
-            let prev_ok =
-                i == 0 || !matches!(bytes[i - 1], b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_');
-            let next_ok =
-                i + 7 == bytes.len() || matches!(bytes[i + 7], b' ' | b'\t' | b'\r' | b'\n');
-            if prev_ok && next_ok {
-                let mut j = i + 7;
-                while j < bytes.len() && matches!(bytes[j], b' ' | b'\t' | b'\r' | b'\n') {
-                    j += 1;
-                }
-                let start = j;
-                while j < bytes.len()
-                    && matches!(
-                        bytes[j],
-                        b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_' | b'.'
-                    )
-                {
-                    j += 1;
-                }
-                if start == j {
-                    return None;
-                }
-                while j < bytes.len() && matches!(bytes[j], b' ' | b'\t' | b'\r' | b'\n') {
-                    j += 1;
-                }
-                if j < bytes.len() && bytes[j] == b';' {
-                    let pkg = String::from_utf8_lossy(&bytes[start..j]).trim().to_string();
-                    return Some(pkg);
-                }
-            }
-        }
+    // Find first `package ...;` statement using regex.
+    // Pattern: word boundary + "package" + whitespace + package name + optional whitespace + semicolon
+    // Package names consist of identifiers separated by dots: [a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*
+    static PACKAGE_RE: OnceLock<Regex> = OnceLock::new();
+    let re = PACKAGE_RE.get_or_init(|| {
+        Regex::new(r"(?m)(?:^|[^a-zA-Z0-9_])package\s+([a-zA-Z_][a-zA-Z0-9_.]*?)\s*;").unwrap()
+    });
 
-        i += 1;
-    }
-
-    None
+    re.captures(&out)
+        .and_then(|caps| caps.get(1))
+        .map(|m| m.as_str().to_string())
 }
 
 /// Scans a directory for `.proto` files and extracts namespace declarations.


### PR DESCRIPTION
## Summary

Follow-up on PR #15 review feedback from André Eisenbach.

André commented that the byte-based loop in `extract_proto_package()` was "not correct by inspection" and suggested using a regex or at least abstracting out helper functions.

This PR replaces the manual byte-by-byte parsing loop with a more readable regex-based approach.

## Changes

- Add `regex` crate dependency
- Use `OnceLock` for lazy regex compilation (no runtime cost for repeated calls)
- Simplify package name extraction to a clear, self-documenting regex pattern