### PR TITLE
feat: add self-update command (v1.2.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +98,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -272,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -316,6 +336,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -337,12 +358,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -357,6 +399,16 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -426,6 +478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +513,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -501,6 +574,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +641,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1382,6 +1482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,6 +1759,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1840,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1802,6 +1930,27 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "matchers"
@@ -1959,6 +2108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2235,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2261,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain"
@@ -2126,6 +2297,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3156,6 +3333,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
 name = "tiny_pretty"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4132,6 +4328,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yaml_parser"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4216,6 +4421,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -4251,6 +4470,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,3 +4510,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "1.2.5"
+version = "1.2.6"
 edition = "2021"
 description = "Modern protobuf package management"
 authors = [
@@ -53,7 +53,7 @@ pretty_yaml = { version = "0.5.0" }
 protobuf = { version = "3.3.0", optional = true }
 protobuf-parse = { version = "3.3.0", optional = true }
 pubgrub = "0.3"
-reqwest = { version = "0.12", features = ["rustls-tls-native-roots"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots"], default-features = false }
 semver = { version = "1", features = ["serde"] }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
@@ -69,6 +69,7 @@ url = { version = "2.4", features = ["serde"] }
 walkdir = "2"
 sha2 = "0.10.8"
 strum = { version = "0.26.2", features = ["derive"] }
+zip = "2.2"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -114,7 +114,7 @@ impl Cache {
         let dir = WalkDir::new(self.path())
             .max_depth(1)
             .into_iter()
-            .filter_map(|e| e.ok());
+            .filter_map(std::result::Result::ok);
 
         let (dirs, files): (Vec<_>, Vec<_>) = dir.partition(|e| e.path().is_dir());
 
@@ -218,6 +218,7 @@ impl Cache {
     }
 
     /// The directory in the filesystem used by this cache
+    #[must_use]
     pub fn path(&self) -> &Path {
         self.0.as_path()
     }
@@ -230,6 +231,7 @@ pub struct Entry(PathBuf);
 
 impl Entry {
     /// The filename of the cache entry
+    #[must_use]
     pub fn filename(&self) -> &Path {
         self.0.as_path()
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -63,7 +63,7 @@ pub async fn init(kind: Option<PackageType>, name: Option<PackageName>) -> miett
 
     let package = kind
         .map(|kind| -> miette::Result<PackageManifest> {
-            let name = name.map(Result::Ok).unwrap_or_else(curr_dir_name)?;
+            let name = name.map_or_else(curr_dir_name, Result::Ok)?;
 
             Ok(PackageManifest {
                 kind,
@@ -149,10 +149,10 @@ impl FromStr for DependencyLocator {
 
         let repository = repository.into();
 
-        let (package, version) = dependency
-            .split_once('@')
-            .map(|(package, version)| (package, Some(version)))
-            .unwrap_or_else(|| (dependency, None));
+        let (package, version) = dependency.split_once('@').map_or_else(
+            || (dependency, None),
+            |(package, version)| (package, Some(version)),
+        );
 
         let package = package
             .parse::<PackageName>()
@@ -404,8 +404,8 @@ async fn rewrite_proto_namespaces_in_dir(dir: &Path, version: &Version) -> miett
     // Collect all proto file paths first to avoid holding WalkDir handles while writing
     let proto_files: Vec<_> = WalkDir::new(dir)
         .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().map_or(false, |ext| ext == "proto"))
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "proto"))
         .map(|e| e.path().to_path_buf())
         .collect();
 
@@ -704,18 +704,18 @@ pub async fn install(
                                 // With Rewrite policy, namespaces should have been rewritten during install.
                                 // A collision here means rewriting didn't apply or these are shared types.
                                 // Check if content is identical (shared base types are OK).
-                                if &content_hash != other_hash {
+                                if &content_hash == other_hash {
+                                    tracing::debug!(
+                                        ":: namespace overlap (identical content): '{}' in {} and {}",
+                                        pkg, other_id, id
+                                    );
+                                } else {
                                     tracing::warn!(
                                         ":: namespace collision after rewrite: '{}' declared by {} and {} with different content",
                                         pkg, other_id, id
                                     );
                                     tracing::warn!(
                                         "   This may indicate a bug in namespace rewriting or incompatible shared types"
-                                    );
-                                } else {
-                                    tracing::debug!(
-                                        ":: namespace overlap (identical content): '{}' in {} and {}",
-                                        pkg, other_id, id
                                     );
                                 }
                             }
@@ -817,14 +817,14 @@ pub async fn list(config: &Config) -> miette::Result<()> {
             .wrap_err(miette!("failed to canonicalize current directory"))?
     };
 
-    for proto in protos.iter() {
+    for proto in &protos {
         let rel = proto
             .strip_prefix(&cwd)
             .into_diagnostic()
             .wrap_err(miette!("failed to transform protobuf path"))?
             .to_posix_string();
 
-        print!("{rel} ")
+        print!("{rel} ");
     }
 
     Ok(())
@@ -866,22 +866,21 @@ pub async fn login(
     let mut credentials = Credentials::load().await?;
     let registry: RegistryUri = registry.with_alias_resolved(Some(config))?.try_into()?;
 
-    let token = match token {
-        Some(token) => token,
-        None => {
-            tracing::info!(":: please enter your artifactory token:");
+    let token = if let Some(token) = token {
+        token
+    } else {
+        tracing::info!(":: please enter your artifactory token:");
 
-            let mut raw = String::new();
-            let mut reader = BufReader::new(io::stdin());
+        let mut raw = String::new();
+        let mut reader = BufReader::new(io::stdin());
 
-            reader
-                .read_line(&mut raw)
-                .await
-                .into_diagnostic()
-                .wrap_err(miette!("failed to read the token from the user"))?;
+        reader
+            .read_line(&mut raw)
+            .await
+            .into_diagnostic()
+            .wrap_err(miette!("failed to read the token from the user"))?;
 
-            raw.trim().into()
-        }
+        raw.trim().into()
     };
 
     credentials.registry_tokens.insert(registry.clone(), token);

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,8 +74,8 @@ pub struct Config {
 struct ResolverConfig {
     allow_multiple_versions: bool,
     skip_link_safety_check: bool,
-    /// Use legacy greedy resolution instead of PubGrub SAT-based resolution.
-    /// Only use this if you encounter issues with PubGrub.
+    /// Use legacy greedy resolution instead of `PubGrub` SAT-based resolution.
+    /// Only use this if you encounter issues with `PubGrub`.
     use_greedy_resolver: bool,
 }
 
@@ -105,6 +105,7 @@ impl Config {
     /// Whether dependency resolution may install multiple versions of the same package name.
     ///
     /// This is opt-in because it can change vendor layout and lockfile behavior.
+    #[must_use]
     pub fn allow_multiple_versions(&self) -> bool {
         self.resolver.allow_multiple_versions
     }
@@ -113,17 +114,19 @@ impl Config {
     ///
     /// WARNING: This is unsafe and should ONLY be used for testing or when you know
     /// that the proto namespaces don't actually conflict at runtime.
+    #[must_use]
     pub fn skip_link_safety_check(&self) -> bool {
         self.resolver.skip_link_safety_check
     }
 
-    /// Use legacy greedy resolution instead of PubGrub.
+    /// Use legacy greedy resolution instead of `PubGrub`.
     ///
     /// When enabled, the resolver uses simple greedy version selection
     /// instead of SAT-based resolution. This may fail on diamond dependencies.
     ///
     /// This is provided for backward compatibility and debugging. The default
-    /// PubGrub resolver should be preferred for most use cases.
+    /// `PubGrub` resolver should be preferred for most use cases.
+    #[must_use]
     pub fn use_greedy_resolver(&self) -> bool {
         self.resolver.use_greedy_resolver
     }
@@ -175,6 +178,7 @@ impl Config {
     ///
     /// # Returns
     /// A vector of default arguments for the specified command
+    #[must_use]
     pub fn get_default_args(&self, command: Option<&str>) -> Vec<String> {
         self.command_defaults
             .get(command.unwrap_or(DEFAULT_ARGS_KEY))
@@ -189,6 +193,7 @@ impl Config {
     ///
     /// # Returns
     /// Some(PathBuf) if the configuration file is found, None otherwise
+    #[must_use]
     pub fn locate_config(cwd: Option<&Path>) -> Option<PathBuf> {
         if let Some(cwd) = cwd {
             let mut current_dir = cwd.to_owned();
@@ -304,19 +309,19 @@ impl Config {
         let allow_multiple_versions = config
             .get("resolver")
             .and_then(|resolver| resolver.get("allow_multiple_versions"))
-            .and_then(|value| value.as_bool())
+            .and_then(toml::Value::as_bool)
             .unwrap_or(false);
 
         let skip_link_safety_check = config
             .get("resolver")
             .and_then(|resolver| resolver.get("skip_link_safety_check"))
-            .and_then(|value| value.as_bool())
+            .and_then(toml::Value::as_bool)
             .unwrap_or(false);
 
         let use_greedy_resolver = config
             .get("resolver")
             .and_then(|resolver| resolver.get("use_greedy_resolver"))
-            .and_then(|value| value.as_bool())
+            .and_then(toml::Value::as_bool)
             .unwrap_or(false);
 
         ResolverConfig {
@@ -351,7 +356,7 @@ impl Config {
             .get("registry")
             .and_then(|registry| registry.get("default"))
             .and_then(|default| default.as_str())
-            .map(|default| default.to_string());
+            .map(std::string::ToString::to_string);
         if let Some(ref default_registry) = default_registry {
             ensure!(
                 registries.contains_key(default_registry),
@@ -415,11 +420,13 @@ impl Config {
                             .and_then(|args| args.as_array())
                             .map(|args| {
                                 args.iter()
-                                    .filter_map(|arg| arg.as_str().map(|s| s.to_string()))
+                                    .filter_map(|arg| {
+                                        arg.as_str().map(std::string::ToString::to_string)
+                                    })
                                     .collect::<Vec<String>>()
                             })
                             .unwrap_or_default();
-                        Ok((command.to_string(), default_args))
+                        Ok((command.clone(), default_args))
                     })
                     .collect::<miette::Result<HashMap<String, Vec<String>>>>()
             })
@@ -437,7 +444,7 @@ impl Config {
         {
             let global_defaults = global_args
                 .iter()
-                .filter_map(|arg| arg.as_str().map(|s| s.to_string()))
+                .filter_map(|arg| arg.as_str().map(std::string::ToString::to_string))
                 .collect::<Vec<String>>();
             command_defaults.insert(DEFAULT_ARGS_KEY.to_string(), global_defaults);
         }

--- a/src/integration/buf_yaml.rs
+++ b/src/integration/buf_yaml.rs
@@ -154,7 +154,7 @@ pub fn generate_buf_yaml_file(
 }
 
 /// Default buf.yaml file
-const DEFAULT_YAML: &str = r#"
+const DEFAULT_YAML: &str = r"
 version: v2
 
 modules:
@@ -169,7 +169,7 @@ breaking:
 deps:
   - buf.build/googleapis/googleapis
   - buf.build/grpc/grpc
-"#;
+";
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Config {

--- a/src/io.rs
+++ b/src/io.rs
@@ -62,7 +62,7 @@ pub trait File: Sized + Send + Sync + 'static {
         P: AsRef<Path> + Send + Sync;
 
     /// Loads the file from the current directory, if it exists, otherwise returns an empty one.
-    /// Fails if the exists() check fails.
+    /// Fails if the `exists()` check fails.
     async fn load_or_default() -> miette::Result<Self>
     where
         Self: Default,
@@ -75,7 +75,7 @@ pub trait File: Sized + Send + Sync + 'static {
     }
 
     /// Loads the file from a specific path, if it exists, otherwise returns an empty one.
-    /// Fails if the exists() check fails.
+    /// Fails if the `exists()` check fails.
     async fn load_from_or_default<P>(path: P) -> miette::Result<Self>
     where
         Self: Default,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ pub mod pubgrub_resolver;
 pub mod registry;
 /// Resolve package dependencies.
 pub mod resolver;
+/// Self-update command.
+pub mod update;
 /// Validation for buffrs packages.
 #[cfg(feature = "validation")]
 pub mod validation;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -84,7 +84,7 @@ impl LockedPackage {
             name: package.name().to_owned(),
             registry,
             repository,
-            digest: package.digest(DigestAlgorithm::SHA256).to_owned(),
+            digest: package.digest(DigestAlgorithm::SHA256).clone(),
             version: package.version().to_owned(),
             dependencies: package
                 .manifest
@@ -98,12 +98,13 @@ impl LockedPackage {
     }
 
     /// Attach resolved dependency versions (optional).
+    #[must_use]
     pub fn with_resolved_dependencies(mut self, dependencies: Vec<LockedDependency>) -> Self {
         self.dependencies_resolved = dependencies;
         self
     }
 
-    /// Validates if another LockedPackage matches this one
+    /// Validates if another `LockedPackage` matches this one
     pub fn validate(&self, package: &Package) -> miette::Result<()> {
         let digest: Digest = DigestAlgorithm::SHA256.digest(&package.tgz);
 
@@ -169,6 +170,7 @@ pub struct LockfileMultiversionState {
 
 impl LockfileMultiversionState {
     /// Returns true if any package has multiple versions.
+    #[must_use]
     pub fn has_multiversion(&self) -> bool {
         !self.multiversion_packages.is_empty()
     }
@@ -262,6 +264,7 @@ impl Lockfile {
     }
 
     /// Locates a given package in the Lockfile
+    #[must_use]
     pub fn get(&self, name: &PackageName) -> Option<&LockedPackage> {
         self.packages.iter().find(|p| &p.name == name)
     }
@@ -269,6 +272,7 @@ impl Lockfile {
     /// Computes the multiversion state of this lockfile.
     ///
     /// Returns information about which packages have multiple versions locked.
+    #[must_use]
     pub fn multiversion_state(&self) -> LockfileMultiversionState {
         use std::collections::HashMap;
         let mut version_counts: HashMap<&PackageName, usize> = HashMap::new();
@@ -287,6 +291,7 @@ impl Lockfile {
     /// Locates a given package in the lockfile by name and version requirement.
     ///
     /// This is required when multiple versions of the same package name are present.
+    #[must_use]
     pub fn find(
         &self,
         name: &PackageName,
@@ -339,7 +344,7 @@ impl File for Lockfile {
                 let raw: RawLockfile = toml::from_str(&contents)
                     .into_diagnostic()
                     .wrap_err(DeserializationError(ManagedFile::Lock))?;
-                Ok(Self::from_iter(raw.packages.into_iter()))
+                Ok(Self::from_iter(raw.packages))
             }
             Err(err) if matches!(err.kind(), std::io::ErrorKind::NotFound) => {
                 Err(FileNotFound(path_str).into())
@@ -379,6 +384,7 @@ pub struct FileRequirement {
 
 impl FileRequirement {
     /// URL where the file can be located.
+    #[must_use]
     pub fn url(&self) -> &Url {
         &self.url
     }

--- a/src/lock/digest.rs
+++ b/src/lock/digest.rs
@@ -33,6 +33,7 @@ pub enum DigestAlgorithm {
 
 impl DigestAlgorithm {
     /// Create a digest of some data using this algorithm.
+    #[must_use]
     pub fn digest(&self, data: &[u8]) -> Digest {
         let digest = match self {
             DigestAlgorithm::SHA256 => sha2::Sha256::new().chain_update(data).finalize().to_vec(),
@@ -96,11 +97,13 @@ impl Digest {
     }
 
     /// Algorithm used to create this digest.
+    #[must_use]
     pub fn algorithm(&self) -> DigestAlgorithm {
         self.algorithm
     }
 
     /// Digest as raw byte data.
+    #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
         &self.digest
     }
@@ -153,7 +156,7 @@ impl Serialize for Digest {
 struct DigestVisitor;
 
 #[allow(clippy::needless_lifetimes)]
-impl<'de> Visitor<'de> for DigestVisitor {
+impl Visitor<'_> for DigestVisitor {
     type Value = Digest;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,17 @@ enum Command {
         #[command(subcommand)]
         command: LockfileCommand,
     },
+
+    /// Update buffrs to the latest version
+    #[command(name = "self-update")]
+    SelfUpdate {
+        /// Force update even if already on latest version
+        #[arg(long)]
+        force: bool,
+        /// Only check for updates without installing
+        #[arg(long)]
+        check_only: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -250,17 +261,15 @@ async fn run(args: &[String]) -> miette::Result<()> {
         Command::Init { lib, api, package } => {
             let kind = infer_package_type(lib, api);
 
-            command::init(kind, package.to_owned())
-                .await
-                .wrap_err(miette!(
-                    "failed to initialize {}",
-                    package.map(|p| format!("`{p}`")).unwrap_or_default()
-                ))
+            command::init(kind, package.clone()).await.wrap_err(miette!(
+                "failed to initialize {}",
+                package.map(|p| format!("`{p}`")).unwrap_or_default()
+            ))
         }
         Command::New { lib, api, package } => {
             let kind = infer_package_type(lib, api);
 
-            command::new(kind, package.to_owned())
+            command::new(kind, package.clone())
                 .await
                 .wrap_err(miette!("failed to initialize {}", format!("`{package}`")))
         }
@@ -288,7 +297,7 @@ async fn run(args: &[String]) -> miette::Result<()> {
                 ))
         }
         Command::Remove { package } => {
-            command::remove(package.to_owned(), &config)
+            command::remove(package.clone(), &config)
                 .await
                 .wrap_err(miette!(
                     "failed to remove `{package}` from `{MANIFEST_FILE}`"
@@ -313,7 +322,7 @@ async fn run(args: &[String]) -> miette::Result<()> {
             let registry = config.parse_registry_arg(&registry)?;
             command::publish(
                 &registry,
-                repository.to_owned(),
+                repository.clone(),
                 allow_dirty,
                 dry_run,
                 set_version,
@@ -359,6 +368,13 @@ async fn run(args: &[String]) -> miette::Result<()> {
                 "failed to print locked file requirements of `{package}`"
             )),
         },
+        Command::SelfUpdate { force, check_only } => {
+            if check_only {
+                buffrs::update::check().await
+            } else {
+                buffrs::update::update(force).await
+            }
+        }
     }
 }
 
@@ -380,6 +396,7 @@ fn infer_package_type(lib: bool, api: bool) -> Option<PackageType> {
 ///
 /// # Returns
 /// A vector of arguments with default arguments merged in
+#[must_use]
 pub fn merge_args_with_defaults(config: &Config, args: &[String]) -> Vec<String> {
     // Check if --ignore-defaults is in the arguments
     let initial_cli = Cli::try_parse_from(args);
@@ -405,7 +422,7 @@ pub fn merge_args_with_defaults(config: &Config, args: &[String]) -> Vec<String>
                 .into_iter()
                 .filter(|arg| !user_args.contains(arg))
                 .collect();
-            args.splice(position + 1..position + 1, filtered_defaults);
+            args.splice((position + 1)..=position, filtered_defaults);
         }
     }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -63,6 +63,7 @@ pub enum Edition {
 
 impl Edition {
     /// The current / latest edition of buffrs
+    #[must_use]
     pub fn latest() -> Self {
         Self::Canary
     }
@@ -290,6 +291,7 @@ pub struct ResolvedManifest(pub Manifest);
 
 impl Manifest {
     /// Create a new manifest of the current edition
+    #[must_use]
     pub fn new(package: Option<PackageManifest>, dependencies: Vec<Dependency>) -> Self {
         Self {
             edition: Edition::latest(),
@@ -458,8 +460,7 @@ impl Manifest {
                     self.package
                         .as_ref()
                         .map(|p| p.name.clone())
-                        .map(|n| n.to_string())
-                        .unwrap_or("package".to_string())
+                        .map_or("package".to_string(), |n| n.to_string())
                 ));
             }
         }
@@ -487,8 +488,7 @@ impl ResolvedManifest {
                             manifest.package
                                 .as_ref()
                                 .map(|p| p.name.clone())
-                                .map(|n| n.to_string())
-                                .unwrap_or("package".to_string())
+                                .map_or("package".to_string(), |n| n.to_string())
                         ));
                     }
                 }
@@ -588,6 +588,7 @@ pub struct Dependency {
 
 impl Dependency {
     /// Creates a new dependency
+    #[must_use]
     pub fn new(
         registry: &RegistryRef,
         repository: String,
@@ -610,6 +611,7 @@ impl Dependency {
     }
 
     /// Creates a copy of this dependency with a pinned version
+    #[must_use]
     pub fn with_version(&self, version: &Version) -> Dependency {
         let mut dependency = self.clone();
 
@@ -629,6 +631,7 @@ impl Dependency {
     }
 
     /// Returns the resolver mode for this dependency edge.
+    #[must_use]
     pub fn resolver_mode(&self) -> ResolverMode {
         match &self.manifest {
             DependencyManifest::Remote(m) => m.resolver,
@@ -639,6 +642,7 @@ impl Dependency {
     }
 
     /// Returns the namespace overlap policy for this dependency edge.
+    #[must_use]
     pub fn namespace_overlap_policy(&self) -> NamespaceOverlapPolicy {
         match &self.manifest {
             DependencyManifest::Remote(m) => m.namespace_overlap,
@@ -651,6 +655,7 @@ impl Dependency {
     }
 
     /// Returns true if this dependency allows multiple versions.
+    #[must_use]
     pub fn allows_multiversion(&self) -> bool {
         matches!(self.resolver_mode(), ResolverMode::MultiVersion)
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -49,7 +49,7 @@ pub const GRAPH_JSON: &str = "graph.json";
 /// Namespaces metadata filename.
 pub const NAMESPACES_JSON: &str = "namespaces.json";
 
-/// CMake targets filename.
+/// `CMake` targets filename.
 pub const BUFFRS_CMAKE: &str = "buffrs.cmake";
 
 /// Serializable representation of the dependency graph.
@@ -74,6 +74,7 @@ pub struct PackageRef {
 
 impl PackageRef {
     /// Creates a new package reference.
+    #[must_use]
     pub fn new(name: &PackageName, version: &Version) -> Self {
         Self {
             name: name.to_string(),
@@ -82,6 +83,7 @@ impl PackageRef {
     }
 
     /// Returns the vendor directory name for this package reference.
+    #[must_use]
     pub fn vendor_dir(&self, version_qualified: bool) -> String {
         if version_qualified {
             format!("{}@{}", self.name, self.version)
@@ -269,7 +271,7 @@ fn build_namespaces_metadata(namespace_scan: &NamespaceScanResult) -> Namespaces
     NamespacesMetadata { namespaces }
 }
 
-/// Builds CMake content for package targets.
+/// Builds `CMake` content for package targets.
 fn build_cmake_targets(
     graph: &DependencyGraph,
     namespace_scan: &NamespaceScanResult,
@@ -313,8 +315,7 @@ fn build_cmake_targets(
             id.version()
         ));
         cmake.push_str(&format!(
-            "set(BUFFRS_PKG_{}_VENDOR_DIR \"{}\")\n",
-            safe_name, vendor_dir
+            "set(BUFFRS_PKG_{safe_name}_VENDOR_DIR \"{vendor_dir}\")\n"
         ));
 
         // Dependencies
@@ -327,7 +328,7 @@ fn build_cmake_targets(
             "set(BUFFRS_PKG_{}_DEPENDENCIES {})\n",
             safe_name,
             if deps.is_empty() {
-                "".to_string()
+                String::new()
             } else {
                 format!("\"{}\"", deps.join("\" \""))
             }
@@ -344,13 +345,13 @@ fn build_cmake_targets(
             "set(BUFFRS_PKG_{}_NAMESPACES {})\n",
             safe_name,
             if namespaces.is_empty() {
-                "".to_string()
+                String::new()
             } else {
                 format!("\"{}\"", namespaces.join("\" \""))
             }
         ));
 
-        cmake.push_str("\n");
+        cmake.push('\n');
     }
 
     // Emit root packages

--- a/src/namespace_scan.rs
+++ b/src/namespace_scan.rs
@@ -66,7 +66,7 @@ pub struct PackageNamespaces {
 #[derive(Debug, Clone, Default)]
 pub struct NamespaceScanResult {
     /// Mapping from namespace to list of packages declaring it with content hash.
-    /// Tuple is (package_name, version, source_file, content_hash).
+    /// Tuple is (`package_name`, version, `source_file`, `content_hash`).
     /// If a namespace maps to multiple packages, there's a potential conflict.
     pub namespace_to_packages: HashMap<String, Vec<(PackageName, Version, String, String)>>,
     /// All packages with their namespace declarations.
@@ -75,6 +75,7 @@ pub struct NamespaceScanResult {
 
 impl NamespaceScanResult {
     /// Returns namespaces that are declared by more than one package@version.
+    #[must_use]
     pub fn conflicts(&self) -> Vec<(&String, &[(PackageName, Version, String, String)])> {
         self.namespace_to_packages
             .iter()
@@ -92,6 +93,7 @@ impl NamespaceScanResult {
 
     /// Returns namespaces where different versions have non-identical content.
     /// This is used for `identical_only` policy validation.
+    #[must_use]
     pub fn content_conflicts(&self) -> Vec<(&String, &[(PackageName, Version, String, String)])> {
         self.namespace_to_packages
             .iter()
@@ -109,6 +111,7 @@ impl NamespaceScanResult {
 }
 
 /// Compute SHA-256 hash of content (hex-encoded).
+#[must_use]
 pub fn content_hash(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
@@ -139,7 +142,7 @@ pub fn extract_proto_package(contents: &str) -> Option<String> {
             match chars.peek().copied() {
                 Some('/') => {
                     // line comment
-                    while let Some(nc) = chars.next() {
+                    for nc in chars.by_ref() {
                         if nc == '\n' {
                             out.push('\n');
                             break;
@@ -179,8 +182,8 @@ pub async fn scan_directory(dir: &Path) -> miette::Result<Vec<NamespaceInfo>> {
 
     for entry in WalkDir::new(dir)
         .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().map_or(false, |ext| ext == "proto"))
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "proto"))
     {
         let path = entry.path();
         let contents = fs::read_to_string(path)
@@ -269,6 +272,7 @@ pub async fn scan_dependency_graph(
 /// - `1.0.0` → `_v1_0_0`
 /// - `0.1.2-SPINE-4384` → `_v0_1_2_SPINE_4384`
 /// - `1.0.0-rc.1` → `_v1_0_0_rc_1`
+#[must_use]
 pub fn version_to_suffix(version: &Version) -> String {
     // Always include all three version components for unambiguous reversibility
     let mut suffix = format!("_v{}_{}_{}", version.major, version.minor, version.patch);
@@ -308,6 +312,7 @@ pub fn version_to_suffix(version: &Version) -> String {
 /// let rewritten = rewrite_proto_package(contents, &version);
 /// assert!(rewritten.contains("package gm.algo.base._v0_1_2;"));
 /// ```
+#[must_use]
 pub fn rewrite_proto_package(contents: &str, version: &Version) -> String {
     let suffix = version_to_suffix(version);
 
@@ -338,7 +343,7 @@ pub fn rewrite_proto_package(contents: &str, version: &Version) -> String {
                     // Line comment - copy until newline
                     result.push(c);
                     result.push(chars.next().unwrap());
-                    while let Some(nc) = chars.next() {
+                    for nc in chars.by_ref() {
                         result.push(nc);
                         if nc == '\n' {
                             break;
@@ -364,9 +369,11 @@ pub fn rewrite_proto_package(contents: &str, version: &Version) -> String {
             if remaining == "ackage" {
                 // Verify it's a keyword boundary (not part of another word)
                 let peek_after: String = chars.clone().skip(6).take(1).collect();
-                if peek_after.chars().next().map_or(true, |ch| {
-                    ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
-                }) {
+                if peek_after
+                    .chars()
+                    .next()
+                    .is_none_or(|ch| ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r')
+                {
                     // Found the package keyword
                     result.push(c);
                     for _ in 0..6 {

--- a/src/package/compressed.rs
+++ b/src/package/compressed.rs
@@ -203,7 +203,10 @@ impl Package {
         #[cfg(windows)]
         {
             use walkdir::WalkDir;
-            for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
+            for entry in WalkDir::new(path)
+                .into_iter()
+                .filter_map(std::result::Result::ok)
+            {
                 if entry.file_type().is_file() {
                     if let Ok(metadata) = std::fs::metadata(entry.path()) {
                         let mut perms = metadata.permissions();
@@ -235,7 +238,7 @@ impl Package {
             .entries()
             .into_diagnostic()
             .wrap_err(miette!("corrupted tar package"))?
-            .filter_map(|entry| entry.ok())
+            .filter_map(std::result::Result::ok)
             .find(|entry| {
                 entry
                     .path()

--- a/src/package/store.rs
+++ b/src/package/store.rs
@@ -67,11 +67,13 @@ impl PackageStore {
     }
 
     /// Path to the `proto` directory.
+    #[must_use]
     pub fn proto_path(&self) -> PathBuf {
         self.root.join(Self::PROTO_PATH)
     }
 
     /// Path to the vendor directory.
+    #[must_use]
     pub fn proto_vendor_path(&self) -> PathBuf {
         self.root.join(Self::PROTO_VENDOR_PATH)
     }
@@ -149,6 +151,7 @@ impl PackageStore {
     }
 
     /// Directory for the vendored installation of a resolved package instance.
+    #[must_use]
     pub fn locate_resolved(&self, id: &ResolvedPackageId, graph: &DependencyGraph) -> PathBuf {
         self.proto_vendor_path().join(id.vendor_dir_name(graph))
     }
@@ -220,7 +223,7 @@ impl PackageStore {
         deps: Option<&DependencyGraph>,
         preserve_mtime: bool,
     ) -> miette::Result<Package> {
-        for dependency in manifest.dependencies.iter() {
+        for dependency in &manifest.dependencies {
             let resolved = if let Some(deps) = deps {
                 deps.get_single_by_name(&dependency.package)
                     .map(|dep| dep.package().manifest.clone())
@@ -273,6 +276,7 @@ impl PackageStore {
     }
 
     /// Directory for the vendored installation of a package
+    #[must_use]
     pub fn locate(&self, package: &PackageName) -> PathBuf {
         self.proto_vendor_path().join(&**package)
     }
@@ -282,7 +286,7 @@ impl PackageStore {
         let mut paths: Vec<_> = WalkDir::new(path)
             .into_iter()
             .filter_map(Result::ok)
-            .map(|entry| entry.into_path())
+            .map(walkdir::DirEntry::into_path)
             .filter(|path| {
                 if vendored {
                     true

--- a/src/pubgrub_resolver.rs
+++ b/src/pubgrub_resolver.rs
@@ -36,7 +36,7 @@ use std::sync::{Arc, RwLock};
 
 use crate::package::PackageName;
 
-/// A package identifier for PubGrub resolution.
+/// A package identifier for `PubGrub` resolution.
 ///
 /// Wraps `PackageName` with a special "root" variant for the resolution root.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -51,7 +51,7 @@ impl fmt::Display for PubGrubPackage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Root => write!(f, "root"),
-            Self::Package(name) => write!(f, "{}", name),
+            Self::Package(name) => write!(f, "{name}"),
         }
     }
 }
@@ -62,12 +62,13 @@ impl From<PackageName> for PubGrubPackage {
     }
 }
 
-/// Version set type for PubGrub using semver::Version.
+/// Version set type for `PubGrub` using `semver::Version`.
 pub type SemverRanges = Ranges<Version>;
 
-/// Converts a semver::VersionReq to PubGrub Ranges.
+/// Converts a `semver::VersionReq` to `PubGrub` Ranges.
 ///
 /// This handles all semver operators: `=`, `^`, `~`, `>`, `>=`, `<`, `<=`, `*`
+#[must_use]
 pub fn version_req_to_ranges(req: &VersionReq) -> SemverRanges {
     if req.comparators.is_empty() {
         // Empty requirement matches everything (equivalent to `*`)
@@ -85,7 +86,7 @@ pub fn version_req_to_ranges(req: &VersionReq) -> SemverRanges {
     result
 }
 
-/// Converts a single semver Comparator to PubGrub Ranges.
+/// Converts a single semver Comparator to `PubGrub` Ranges.
 fn comparator_to_ranges(comp: &Comparator) -> SemverRanges {
     let major = comp.major;
     let minor = comp.minor;
@@ -190,19 +191,16 @@ fn caret_range(
 
 /// Implements wildcard (*) version ranges.
 fn wildcard_range(major: u64, minor: Option<u64>) -> SemverRanges {
-    match minor {
-        Some(m) => {
-            // X.Y.* matches [X.Y.0, X.(Y+1).0)
-            let min = Version::new(major, m, 0);
-            let max = Version::new(major, m + 1, 0);
-            range_between(&min, &max)
-        }
-        None => {
-            // X.* matches [X.0.0, (X+1).0.0)
-            let min = Version::new(major, 0, 0);
-            let max = Version::new(major + 1, 0, 0);
-            range_between(&min, &max)
-        }
+    if let Some(m) = minor {
+        // X.Y.* matches [X.Y.0, X.(Y+1).0)
+        let min = Version::new(major, m, 0);
+        let max = Version::new(major, m + 1, 0);
+        range_between(&min, &max)
+    } else {
+        // X.* matches [X.0.0, (X+1).0.0)
+        let min = Version::new(major, 0, 0);
+        let max = Version::new(major + 1, 0, 0);
+        range_between(&min, &max)
     }
 }
 
@@ -227,7 +225,7 @@ pub struct PackageInfo {
 /// A dependency provider that uses pre-fetched package data.
 ///
 /// This provider is populated by querying the registry for all packages
-/// before running the PubGrub resolution.
+/// before running the `PubGrub` resolution.
 pub struct BuffrsDependencyProvider {
     /// Package data cache
     packages: Arc<RwLock<HashMap<PackageName, PackageInfo>>>,
@@ -242,6 +240,7 @@ pub struct BuffrsDependencyProvider {
 
 impl BuffrsDependencyProvider {
     /// Creates a new dependency provider with the given root dependencies.
+    #[must_use]
     pub fn new(root_deps: Vec<PackageDependency>) -> Self {
         Self {
             packages: Arc::new(RwLock::new(HashMap::new())),
@@ -265,6 +264,7 @@ impl BuffrsDependencyProvider {
     }
 
     /// Gets the available versions for a package.
+    #[must_use]
     pub fn get_versions(&self, name: &PackageName) -> Option<Vec<Version>> {
         let packages = self.packages.read().unwrap();
         packages.get(name).map(|info| info.versions.clone())
@@ -388,8 +388,7 @@ impl DependencyProvider for BuffrsDependencyProvider {
                     }
                 } else {
                     Ok(Dependencies::Unavailable(format!(
-                        "package {} not found in registry",
-                        name
+                        "package {name} not found in registry"
                     )))
                 }
             }
@@ -397,7 +396,7 @@ impl DependencyProvider for BuffrsDependencyProvider {
     }
 }
 
-/// Result of PubGrub resolution.
+/// Result of `PubGrub` resolution.
 pub type ResolutionResult = Result<HashMap<PackageName, Version>, ResolutionError>;
 
 /// Error returned when resolution fails.
@@ -415,7 +414,7 @@ impl fmt::Display for ResolutionError {
 
 impl std::error::Error for ResolutionError {}
 
-/// Runs PubGrub resolution with the given dependency provider.
+/// Runs `PubGrub` resolution with the given dependency provider.
 ///
 /// Returns a map of package names to resolved versions.
 pub fn resolve(provider: &BuffrsDependencyProvider) -> ResolutionResult {
@@ -438,7 +437,7 @@ pub fn resolve(provider: &BuffrsDependencyProvider) -> ResolutionResult {
             Err(ResolutionError { message: report })
         }
         Err(err) => Err(ResolutionError {
-            message: format!("{:?}", err),
+            message: format!("{err:?}"),
         }),
     }
 }

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -38,7 +38,7 @@ pub enum CertValidationPolicy {
 /// Environment variable for specifying a custom CA bundle file
 pub const ENV_CA_BUNDLE: &str = "BUFFRS_CA_BUNDLE";
 
-/// Builds a configured reqwest::Client for Artifactory operations.
+/// Builds a configured `reqwest::Client` for Artifactory operations.
 ///
 /// This helper ensures consistent TLS and redirect configuration across all
 /// Artifactory clients. Use this when creating a shared client to be passed
@@ -117,7 +117,7 @@ impl Artifactory {
         Self::new_with_client(registry, credentials, client)
     }
 
-    /// Creates a new instance with a pre-built reqwest::Client.
+    /// Creates a new instance with a pre-built `reqwest::Client`.
     ///
     /// Use this when you want to share a connection pool across multiple
     /// Artifactory clients within the same invocation.
@@ -125,7 +125,7 @@ impl Artifactory {
     /// # Arguments
     /// * `registry` - The registry URI
     /// * `credentials` - The credentials to use for the registry
-    /// * `client` - A pre-configured reqwest::Client (use `build_reqwest_client`)
+    /// * `client` - A pre-configured `reqwest::Client` (use `build_reqwest_client`)
     pub fn new_with_client(
         registry: RegistryUri,
         credentials: &Credentials,
@@ -152,7 +152,7 @@ impl Artifactory {
     /// Pings artifactory to ensure registry access is working
     pub async fn ping(&self) -> miette::Result<()> {
         let repositories_url: Url = {
-            let mut uri: url::Url = self.registry.to_owned().into();
+            let mut uri: url::Url = self.registry.clone().into();
             let path = &format!("{}/api/repositories", uri.path());
             uri.set_path(path);
             uri
@@ -174,7 +174,7 @@ impl Artifactory {
     ) -> miette::Result<Vec<Version>> {
         // Retrieve all packages matching the given name
         let search_query_url: Url = {
-            let mut uri: url::Url = self.registry.to_owned().into();
+            let mut uri: url::Url = self.registry.clone().into();
             uri.set_path("artifactory/api/search/artifact");
             uri.set_query(Some(&format!("name={name}&repos={repository}")));
             uri
@@ -285,8 +285,7 @@ impl Artifactory {
             let path = url.path();
 
             url.set_path(&format!(
-                "{}/{}/{}/{}-{}.tgz",
-                path, repository, name, name, version_str
+                "{path}/{repository}/{name}/{name}-{version_str}.tgz"
             ));
 
             url

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -36,11 +36,13 @@ pub struct RegistryUri(Url);
 
 impl RegistryUri {
     /// Get the host component of the registry URI
+    #[must_use]
     pub fn host(&self) -> Option<&str> {
         self.0.host_str()
     }
 
     /// Get the path component of the registry URI
+    #[must_use]
     pub fn path(&self) -> &str {
         self.0.path()
     }
@@ -104,7 +106,7 @@ impl RegistryRef {
         }
     }
 
-    /// Serializer for resolved RegistryUris
+    /// Serializer for resolved `RegistryUris`
     pub fn serialize_resolved<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -222,7 +224,7 @@ impl FromStr for RegistryUri {
 ///
 /// A valid registry URL must:
 /// - Have a scheme of either "http" or "https"
-/// - End with "/artifactory" if the host is a JFrog Artifactory instance
+/// - End with "/artifactory" if the host is a `JFrog` Artifactory instance
 /// - Have a host component
 ///
 /// # Arguments
@@ -288,7 +290,7 @@ fn dependency_version_string(dependency: &Dependency) -> miette::Result<String> 
         minor_version,
         patch_version,
         if version.pre.is_empty() {
-            "".to_owned()
+            String::new()
         } else {
             format!("-{}", version.pre)
         }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -37,16 +37,19 @@ pub struct ResolvedPackageId {
 
 impl ResolvedPackageId {
     /// Creates a new resolved package identifier.
+    #[must_use]
     pub fn new(name: PackageName, version: Version) -> Self {
         Self { name, version }
     }
 
     /// Returns the package name for this resolved instance.
+    #[must_use]
     pub fn name(&self) -> &PackageName {
         &self.name
     }
 
     /// Returns the resolved package version for this instance.
+    #[must_use]
     pub fn version(&self) -> &Version {
         &self.version
     }
@@ -59,6 +62,7 @@ impl ResolvedPackageId {
     /// Note: The `resolver = "multiversion"` setting only grants *permission* to
     /// have multiple versions; it doesn't force version-qualified names when
     /// there's only one version.
+    #[must_use]
     pub fn vendor_dir_name(&self, graph: &DependencyGraph) -> String {
         // Only use version-qualified names when there are actually multiple versions
         if graph.ids_for_name(&self.name).len() > 1 {
@@ -209,6 +213,7 @@ struct DownloadError {
 
 impl DependencyGraph {
     /// Creates a new dependency graph.
+    #[must_use]
     pub fn new(allow_multiple_versions: bool) -> Self {
         Self {
             allow_multiple_versions,
@@ -220,6 +225,7 @@ impl DependencyGraph {
     }
 
     /// Locates and returns a reference to a resolved dependency package by its id.
+    #[must_use]
     pub fn get(&self, id: &ResolvedPackageId) -> Option<&ResolvedDependency> {
         self.entries.get(id)
     }
@@ -230,11 +236,13 @@ impl DependencyGraph {
     }
 
     /// Returns the resolved root dependencies corresponding to the root manifest dependencies.
+    #[must_use]
     pub fn roots(&self) -> &[ResolvedPackageId] {
         &self.roots
     }
 
     /// Returns true if multi-version is globally enabled (deprecated config flag).
+    #[must_use]
     pub fn allow_multiple_versions(&self) -> bool {
         self.allow_multiple_versions
     }
@@ -242,6 +250,7 @@ impl DependencyGraph {
     /// Returns true if multi-version is permitted for a specific package name.
     ///
     /// This checks both the global config flag and per-dependency opt-in.
+    #[must_use]
     pub fn is_multiversion_permitted(&self, name: &PackageName) -> bool {
         self.allow_multiple_versions || self.multiversion_permitted.contains(name)
     }
@@ -249,6 +258,7 @@ impl DependencyGraph {
     /// Returns the effective namespace overlap policy for a package name.
     ///
     /// If multiple edges specify different policies, the most permissive wins.
+    #[must_use]
     pub fn namespace_policy(&self, name: &PackageName) -> NamespaceOverlapPolicy {
         self.namespace_policies
             .get(name)
@@ -284,7 +294,8 @@ impl DependencyGraph {
     ///
     /// A package needs rewriting if:
     /// 1. Multiple versions of this package name exist in the graph, AND
-    /// 2. The namespace_overlap policy is `Rewrite` (default)
+    /// 2. The `namespace_overlap` policy is `Rewrite` (default)
+    #[must_use]
     pub fn needs_namespace_rewrite(&self, id: &ResolvedPackageId) -> bool {
         // Check if multiple versions exist
         let versions_count = self
@@ -303,6 +314,7 @@ impl DependencyGraph {
     }
 
     /// Returns a list of vendor module directory names used by this graph.
+    #[must_use]
     pub fn vendor_module_names(&self) -> Vec<String> {
         let mut modules: Vec<String> = self
             .entries
@@ -316,6 +328,7 @@ impl DependencyGraph {
     }
 
     /// Returns all resolved ids for the given package name.
+    #[must_use]
     pub fn ids_for_name(&self, name: &PackageName) -> Vec<ResolvedPackageId> {
         self.entries
             .keys()
@@ -327,6 +340,7 @@ impl DependencyGraph {
     /// Returns the only resolved dependency for a package name.
     ///
     /// This is useful for legacy call sites that assume single-version resolution.
+    #[must_use]
     pub fn get_single_by_name(&self, name: &PackageName) -> Option<&ResolvedDependency> {
         let mut matches = self.entries.iter().filter(|(id, _)| id.name() == name);
         let first = matches.next()?;
@@ -359,6 +373,7 @@ impl<'a> DependencyGraphBuilder<'a> {
     ///
     /// # Returns
     /// A new dependency graph builder
+    #[must_use]
     pub fn new(
         manifest: &'a Manifest,
         lockfile: &'a Lockfile,
@@ -382,6 +397,7 @@ impl<'a> DependencyGraphBuilder<'a> {
     ///
     /// When set, all Artifactory registry operations will reuse this client's
     /// connection pool instead of creating new connections for each request.
+    #[must_use]
     pub fn with_client(mut self, client: reqwest::Client) -> Self {
         self.client = Some(client);
         self
@@ -412,8 +428,7 @@ impl<'a> DependencyGraphBuilder<'a> {
             .manifest
             .package
             .as_ref()
-            .map(|p| p.name.clone())
-            .unwrap_or_else(|| PackageName::unchecked("."));
+            .map_or_else(|| PackageName::unchecked("."), |p| p.name.clone());
 
         let parent_dir = env::current_dir().into_diagnostic()?;
 
@@ -604,8 +619,7 @@ impl<'a> DependencyGraphBuilder<'a> {
             .manifest
             .publish
             .as_ref()
-            .map(|p| matches!(p.resolver, ResolverMode::MultiVersion))
-            .unwrap_or(false);
+            .is_some_and(|p| matches!(p.resolver, ResolverMode::MultiVersion));
         let namespace_overlap_policy = dependency
             .manifest
             .publish
@@ -935,22 +949,22 @@ impl<'a> DependencyGraphBuilder<'a> {
                 version_req,
                 available
                     .iter()
-                    .map(|v| v.to_string())
+                    .map(std::string::ToString::to_string)
                     .collect::<Vec<_>>()
                     .join(", ")
             )
         })
     }
 
-    /// Builds the dependency graph using PubGrub SAT-based resolution.
+    /// Builds the dependency graph using `PubGrub` SAT-based resolution.
     ///
     /// This method uses a three-phase approach:
     /// 1. Discovery: Fetch all package metadata from registries (and local manifests)
-    /// 2. Resolution: Run PubGrub to find consistent versions
+    /// 2. Resolution: Run `PubGrub` to find consistent versions
     /// 3. Download: Download packages with resolved versions
     ///
     /// Note: Falls back to greedy resolution when multiversion is required,
-    /// since PubGrub inherently produces single-version solutions.
+    /// since `PubGrub` inherently produces single-version solutions.
     async fn build_with_pubgrub(self) -> miette::Result<DependencyGraph> {
         // Check if any dependency has multiversion enabled - if so, use greedy
         // PubGrub produces single-version solutions per package, but multiversion
@@ -964,8 +978,7 @@ impl<'a> DependencyGraphBuilder<'a> {
                 DependencyManifest::Local(m) => m
                     .publish
                     .as_ref()
-                    .map(|p| matches!(p.resolver, ResolverMode::MultiVersion))
-                    .unwrap_or(false),
+                    .is_some_and(|p| matches!(p.resolver, ResolverMode::MultiVersion)),
             });
 
         if has_multiversion {
@@ -979,8 +992,7 @@ impl<'a> DependencyGraphBuilder<'a> {
             .manifest
             .package
             .as_ref()
-            .map(|p| p.name.clone())
-            .unwrap_or_else(|| PackageName::unchecked("."));
+            .map_or_else(|| PackageName::unchecked("."), |p| p.name.clone());
 
         let parent_dir = env::current_dir().into_diagnostic()?;
 
@@ -1050,7 +1062,7 @@ impl<'a> DependencyGraphBuilder<'a> {
                     let store = PackageStore::open(&abs_manifest_dir).await?;
                     let mut temp_deps = DependencyGraph::new(self.config.allow_multiple_versions());
                     let package = store
-                        .release(&local_manifest, self.config, Some(&mut temp_deps), false)
+                        .release(&local_manifest, self.config, Some(&temp_deps), false)
                         .await?;
 
                     let version = package.version().clone();
@@ -1060,7 +1072,7 @@ impl<'a> DependencyGraphBuilder<'a> {
                         publish.version.clone()
                     } else {
                         // If no version specified, create exact requirement
-                        VersionReq::parse(&format!("={}", version)).unwrap()
+                        VersionReq::parse(&format!("={version}")).unwrap()
                     };
 
                     root_deps.push(PackageDependency {
@@ -1122,8 +1134,7 @@ impl<'a> DependencyGraphBuilder<'a> {
                         let sub_version_req = dep_manifest
                             .publish
                             .as_ref()
-                            .map(|p| p.version.clone())
-                            .unwrap_or(VersionReq::STAR);
+                            .map_or(VersionReq::STAR, |p| p.version.clone());
                         pkg_deps.push(PackageDependency {
                             package: dep.package.clone(),
                             version_req: sub_version_req,
@@ -1213,8 +1224,7 @@ impl<'a> DependencyGraphBuilder<'a> {
                                     let sub_version_req = dep_manifest
                                         .publish
                                         .as_ref()
-                                        .map(|p| p.version.clone())
-                                        .unwrap_or(VersionReq::STAR);
+                                        .map_or(VersionReq::STAR, |p| p.version.clone());
                                     pkg_deps.push(PackageDependency {
                                         package: dep.package.clone(),
                                         version_req: sub_version_req,
@@ -1258,7 +1268,7 @@ impl<'a> DependencyGraphBuilder<'a> {
             resolved.len(),
             resolved
                 .iter()
-                .map(|(name, version)| format!("{}@{}", name, version))
+                .map(|(name, version)| format!("{name}@{version}"))
                 .collect::<Vec<_>>()
                 .join(", ")
         );
@@ -1338,8 +1348,7 @@ impl<'a> DependencyGraphBuilder<'a> {
                     let allows_multiversion = manifest
                         .publish
                         .as_ref()
-                        .map(|p| matches!(p.resolver, ResolverMode::MultiVersion))
-                        .unwrap_or(false);
+                        .is_some_and(|p| matches!(p.resolver, ResolverMode::MultiVersion));
                     let namespace_overlap_policy = manifest
                         .publish
                         .as_ref()
@@ -1370,7 +1379,7 @@ impl<'a> DependencyGraphBuilder<'a> {
         Ok(deps)
     }
 
-    /// Recursively builds sub-dependencies using pre-resolved versions from PubGrub.
+    /// Recursively builds sub-dependencies using pre-resolved versions from `PubGrub`.
     #[async_recursion]
     async fn build_pubgrub_subdeps(
         &self,
@@ -1457,11 +1466,10 @@ impl<'a> DependencyGraphBuilder<'a> {
                         // Check if already processed
                         if let Some(existing) = deps.get_mut(&dep_id) {
                             if let ResolvedDependency::Local { dependants, .. } = existing {
-                                let allows_multiversion = manifest
-                                    .publish
-                                    .as_ref()
-                                    .map(|p| matches!(p.resolver, ResolverMode::MultiVersion))
-                                    .unwrap_or(false);
+                                let allows_multiversion =
+                                    manifest.publish.as_ref().is_some_and(|p| {
+                                        matches!(p.resolver, ResolverMode::MultiVersion)
+                                    });
                                 let namespace_overlap_policy = manifest
                                     .publish
                                     .as_ref()
@@ -1487,8 +1495,7 @@ impl<'a> DependencyGraphBuilder<'a> {
                         let allows_multiversion = manifest
                             .publish
                             .as_ref()
-                            .map(|p| matches!(p.resolver, ResolverMode::MultiVersion))
-                            .unwrap_or(false);
+                            .is_some_and(|p| matches!(p.resolver, ResolverMode::MultiVersion));
                         let namespace_overlap_policy = manifest
                             .publish
                             .as_ref()

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,393 @@
+// Copyright 2023 Helsing GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Self-update command — downloads the latest buffrs binary from GitHub Releases.
+
+use miette::{bail, miette, Context, IntoDiagnostic};
+use std::env;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const GITHUB_REPO: &str = "globusmedical/ext-buffrs";
+const RELEASE_TAG_PREFIX: &str = "gm/v";
+
+#[cfg(target_os = "windows")]
+const GH_BINARY_NAME: &str = "gh.exe";
+
+#[cfg(not(target_os = "windows"))]
+const GH_BINARY_NAME: &str = "gh";
+
+// Target triples used in release asset names
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+const TARGET_TRIPLE: &str = "x86_64-unknown-linux-gnu";
+
+#[cfg(all(target_os = "linux", target_arch = "arm"))]
+const TARGET_TRIPLE: &str = "arm-unknown-linux-gnueabihf";
+
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+const TARGET_TRIPLE: &str = "x86_64-apple-darwin";
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const TARGET_TRIPLE: &str = "aarch64-apple-darwin";
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+const TARGET_TRIPLE: &str = "x86_64-pc-windows-msvc";
+
+#[cfg(all(target_os = "windows", target_arch = "x86"))]
+const TARGET_TRIPLE: &str = "i686-pc-windows-msvc";
+
+#[cfg(target_os = "windows")]
+const BINARY_NAME: &str = "buffrs.exe";
+
+#[cfg(not(target_os = "windows"))]
+const BINARY_NAME: &str = "buffrs";
+
+/// Check for available updates without installing.
+pub async fn check() -> miette::Result<()> {
+    let current_version = env!("CARGO_PKG_VERSION");
+
+    println!("Current version: {current_version}");
+    println!("Checking for updates...");
+
+    let latest_version = get_latest_release().await?;
+
+    if latest_version == current_version {
+        println!("✓ You are running the latest version");
+    } else {
+        println!("⚠ Update available: {latest_version}");
+        println!("Run 'buffrs self-update' to install the latest version");
+    }
+
+    Ok(())
+}
+
+/// Update to the latest version.
+pub async fn update(force: bool) -> miette::Result<()> {
+    let current_version = env!("CARGO_PKG_VERSION");
+
+    println!("Current version: {current_version}");
+    println!("Checking for updates...");
+
+    let latest_version = get_latest_release().await?;
+
+    if latest_version == current_version && !force {
+        println!("✓ You are already running the latest version");
+        return Ok(());
+    }
+
+    if force {
+        println!("Forcing update to version {latest_version}...");
+    } else {
+        println!("Updating to version {latest_version}...");
+    }
+
+    let bytes = download_archive(&latest_version).await?;
+    println!("Downloaded {} bytes", bytes.len());
+
+    let current_exe = env::current_exe()
+        .into_diagnostic()
+        .wrap_err("failed to get current executable path")?;
+    let temp_path = get_temp_path(&current_exe);
+    let backup_path = get_backup_path(&current_exe);
+
+    fs::write(&temp_path, &bytes)
+        .into_diagnostic()
+        .wrap_err("failed to write temporary file")?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&temp_path).into_diagnostic()?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&temp_path, perms).into_diagnostic()?;
+    }
+
+    fs::rename(&current_exe, &backup_path)
+        .into_diagnostic()
+        .wrap_err("failed to backup current binary")?;
+
+    if let Err(e) = fs::rename(&temp_path, &current_exe) {
+        // Rollback on failure
+        let _ = fs::rename(&backup_path, &current_exe);
+        bail!("failed to install update: {e}");
+    }
+
+    let _ = fs::remove_file(&backup_path);
+
+    println!("✓ Successfully updated to version {latest_version}");
+    println!("Restart buffrs to use the new version");
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+//  Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Locate the `gh` CLI executable (next to our binary, then in `PATH`).
+fn find_gh_cli() -> Option<PathBuf> {
+    if let Ok(current_exe) = env::current_exe() {
+        if let Some(exe_dir) = current_exe.parent() {
+            let gh_path = exe_dir.join(GH_BINARY_NAME);
+            if gh_path.exists() {
+                return Some(gh_path);
+            }
+        }
+    }
+
+    if Command::new("gh")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+    {
+        return Some(PathBuf::from("gh"));
+    }
+
+    None
+}
+
+/// Run a `gh` CLI command with the given arguments.
+fn run_gh_command<I, S>(args: I, working_dir: &Path) -> Option<std::process::Output>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let gh_path = find_gh_cli()?;
+    Command::new(gh_path)
+        .args(args)
+        .current_dir(working_dir)
+        .output()
+        .ok()
+}
+
+/// Download bytes via HTTP (fallback when `gh` is unavailable).
+async fn download_via_http(url: &str) -> miette::Result<Vec<u8>> {
+    let client = reqwest::Client::builder()
+        .user_agent("buffrs-cli")
+        .build()
+        .into_diagnostic()
+        .wrap_err("failed to create HTTP client")?;
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to download update")?;
+
+    if !response.status().is_success() {
+        bail!("failed to download update: HTTP {}", response.status());
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to read response body")?;
+
+    Ok(bytes.to_vec())
+}
+
+/// Archive asset name for this platform (e.g. `v1.2.5-x86_64-unknown-linux-gnu.tar.gz`).
+fn archive_asset_name(version: &str) -> String {
+    #[cfg(target_os = "windows")]
+    {
+        format!("v{version}-{TARGET_TRIPLE}.zip")
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        format!("v{version}-{TARGET_TRIPLE}.tar.gz")
+    }
+}
+
+/// Download and extract the buffrs binary from a release archive.
+async fn download_archive(version: &str) -> miette::Result<Vec<u8>> {
+    let asset_name = archive_asset_name(version);
+    let temp_dir = std::env::temp_dir();
+    let temp_download = temp_dir.join(&asset_name);
+    let _ = fs::remove_file(&temp_download);
+
+    let gh_download = run_gh_command(
+        [
+            "release",
+            "download",
+            &format!("{RELEASE_TAG_PREFIX}{version}"),
+            "--pattern",
+            &asset_name,
+            "--repo",
+            GITHUB_REPO,
+            "--dir",
+            ".",
+            "--clobber",
+        ],
+        &temp_dir,
+    );
+
+    let archive_bytes = if let Some(output) = gh_download {
+        if output.status.success() {
+            fs::read(&temp_download)
+                .into_diagnostic()
+                .wrap_err("failed to read downloaded archive")?
+        } else {
+            let download_url = format!(
+                "https://github.com/{GITHUB_REPO}/releases/download/{RELEASE_TAG_PREFIX}{version}/{asset_name}"
+            );
+            download_via_http(&download_url).await?
+        }
+    } else {
+        let download_url = format!(
+            "https://github.com/{GITHUB_REPO}/releases/download/{RELEASE_TAG_PREFIX}{version}/{asset_name}"
+        );
+        download_via_http(&download_url).await?
+    };
+
+    extract_binary_from_archive(&archive_bytes)
+}
+
+/// Extract the `buffrs` binary from the release archive.
+fn extract_binary_from_archive(archive_bytes: &[u8]) -> miette::Result<Vec<u8>> {
+    #[cfg(target_os = "windows")]
+    {
+        use std::io::{Cursor, Read};
+        let cursor = Cursor::new(archive_bytes);
+        let mut zip = zip::ZipArchive::new(cursor)
+            .into_diagnostic()
+            .wrap_err("failed to open ZIP archive")?;
+
+        for i in 0..zip.len() {
+            let mut file = zip
+                .by_index(i)
+                .into_diagnostic()
+                .wrap_err("failed to read ZIP entry")?;
+            if file.name().ends_with(BINARY_NAME) {
+                let mut contents = Vec::new();
+                file.read_to_end(&mut contents)
+                    .into_diagnostic()
+                    .wrap_err("failed to read binary from ZIP")?;
+                return Ok(contents);
+            }
+        }
+        bail!("binary '{BINARY_NAME}' not found in ZIP archive");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+
+        let decompressor = GzDecoder::new(archive_bytes);
+        let mut archive = tar::Archive::new(decompressor);
+
+        for entry_result in archive
+            .entries()
+            .into_diagnostic()
+            .wrap_err("failed to read tar entries")?
+        {
+            let mut entry = entry_result
+                .into_diagnostic()
+                .wrap_err("failed to read tar entry")?;
+            let path = entry
+                .path()
+                .into_diagnostic()
+                .wrap_err("failed to get entry path")?;
+
+            if path.to_string_lossy().ends_with(BINARY_NAME) {
+                let mut contents = Vec::new();
+                entry
+                    .read_to_end(&mut contents)
+                    .into_diagnostic()
+                    .wrap_err("failed to read binary from tar")?;
+                return Ok(contents);
+            }
+        }
+        bail!("binary '{BINARY_NAME}' not found in tar.gz archive");
+    }
+}
+
+/// Retrieve the latest release version string (without prefix) from GitHub.
+async fn get_latest_release() -> miette::Result<String> {
+    // Try gh CLI first (handles private repo auth automatically)
+    if let Some(gh_path) = find_gh_cli() {
+        if let Ok(output) = Command::new(gh_path)
+            .args(["api", &format!("repos/{GITHUB_REPO}/releases/latest")])
+            .output()
+        {
+            if output.status.success() {
+                let release: serde_json::Value = serde_json::from_slice(&output.stdout)
+                    .into_diagnostic()
+                    .wrap_err("failed to parse release JSON from gh CLI")?;
+
+                let tag_name = release["tag_name"]
+                    .as_str()
+                    .ok_or_else(|| miette!("missing tag_name in release"))?;
+
+                let version = tag_name
+                    .strip_prefix(RELEASE_TAG_PREFIX)
+                    .ok_or_else(|| miette!("unexpected tag format: {tag_name}"))?;
+
+                return Ok(version.to_string());
+            }
+        }
+    }
+
+    // Fallback to direct GitHub API call
+    let url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest");
+
+    let client = reqwest::Client::builder()
+        .user_agent("buffrs-cli")
+        .build()
+        .into_diagnostic()
+        .wrap_err("failed to create HTTP client")?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to fetch latest release")?;
+
+    if !response.status().is_success() {
+        bail!("failed to fetch latest release: HTTP {}", response.status());
+    }
+
+    let release: serde_json::Value = response
+        .json()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to parse release JSON")?;
+
+    let tag_name = release["tag_name"]
+        .as_str()
+        .ok_or_else(|| miette!("missing tag_name in release"))?;
+
+    let version = tag_name
+        .strip_prefix(RELEASE_TAG_PREFIX)
+        .ok_or_else(|| miette!("unexpected tag format: {tag_name}"))?;
+
+    Ok(version.to_string())
+}
+
+fn get_temp_path(current_exe: &Path) -> PathBuf {
+    let mut temp = current_exe.to_path_buf();
+    temp.set_extension("tmp");
+    temp
+}
+
+fn get_backup_path(current_exe: &Path) -> PathBuf {
+    let mut backup = current_exe.to_path_buf();
+    backup.set_extension("bak");
+    backup
+}

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -39,6 +39,7 @@ pub struct Validator {
 
 impl Validator {
     /// Create new parser with a given root path.
+    #[must_use]
     pub fn new(root: &Path, manifest: &PackageManifest) -> Self {
         Self {
             parser: Parser::new(root),

--- a/src/validation/data/message.rs
+++ b/src/validation/data/message.rs
@@ -129,8 +129,15 @@ pub enum FieldType {
 
 impl From<FieldDescriptorType> for FieldType {
     fn from(type_: FieldDescriptorType) -> Self {
-        use FieldDescriptorType::*;
-        use FieldType::*;
+        use FieldDescriptorType::{
+            TYPE_BOOL, TYPE_BYTES, TYPE_DOUBLE, TYPE_ENUM, TYPE_FIXED32, TYPE_FIXED64, TYPE_FLOAT,
+            TYPE_GROUP, TYPE_INT32, TYPE_INT64, TYPE_MESSAGE, TYPE_SFIXED32, TYPE_SFIXED64,
+            TYPE_SINT32, TYPE_SINT64, TYPE_STRING, TYPE_UINT32, TYPE_UINT64,
+        };
+        use FieldType::{
+            Bool, Bytes, Double, Enum, Fixed32, Fixed64, Float, Group, Int32, Int64, Message,
+            Sfixed32, Sfixed64, Sint32, Sint64, String, Uint32, Uint64,
+        };
         match type_ {
             TYPE_DOUBLE => Double,
             TYPE_FLOAT => Float,
@@ -171,8 +178,8 @@ pub enum FieldLabel {
 
 impl From<FieldDescriptorLabel> for FieldLabel {
     fn from(label: FieldDescriptorLabel) -> Self {
-        use FieldDescriptorLabel::*;
-        use FieldLabel::*;
+        use FieldDescriptorLabel::{LABEL_OPTIONAL, LABEL_REPEATED, LABEL_REQUIRED};
+        use FieldLabel::{Optional, Repeated, Required};
         match label {
             LABEL_OPTIONAL => Optional,
             LABEL_REQUIRED => Required,

--- a/src/validation/data/package.rs
+++ b/src/validation/data/package.rs
@@ -80,7 +80,7 @@ impl Package {
     pub fn add(&mut self, descriptor: &FileDescriptorProto) -> Result<(), PackageError> {
         if descriptor.package() != self.name {
             return Err(PackageError::WrongPackage {
-                expected: self.name.to_owned(),
+                expected: self.name.clone(),
                 got: descriptor.package().to_owned(),
             });
         }

--- a/src/validation/parse.rs
+++ b/src/validation/parse.rs
@@ -54,7 +54,7 @@ impl Parser {
             .file
             .iter()
             .try_fold(Packages::default(), |mut packages, item| {
-                packages.add(item).map(|_| packages)
+                packages.add(item).map(|()| packages)
             })?;
 
         Ok(packages)

--- a/src/version.rs
+++ b/src/version.rs
@@ -51,6 +51,7 @@ use semver::{Comparator, Op, Version, VersionReq};
 /// let req = VersionReq::parse("~1.0.0").unwrap();
 /// assert_eq!(select_version(&req, &available), Some(Version::parse("1.0.0").unwrap()));
 /// ```
+#[must_use]
 pub fn select_version(req: &VersionReq, available: &[Version]) -> Option<Version> {
     available.iter().filter(|v| req.matches(v)).max().cloned()
 }
@@ -58,6 +59,7 @@ pub fn select_version(req: &VersionReq, available: &[Version]) -> Option<Version
 /// Checks if a version requirement specifies an exact version.
 ///
 /// Returns `true` if the requirement has exactly one comparator with `Op::Exact`.
+#[must_use]
 pub fn is_exact_requirement(req: &VersionReq) -> bool {
     req.comparators.len() == 1 && req.comparators.first().is_some_and(|c| c.op == Op::Exact)
 }
@@ -65,6 +67,7 @@ pub fn is_exact_requirement(req: &VersionReq) -> bool {
 /// Extracts the exact version from a requirement that specifies one.
 ///
 /// Returns `None` if the requirement is not exact or is malformed.
+#[must_use]
 pub fn extract_exact_version(req: &VersionReq) -> Option<Version> {
     if !is_exact_requirement(req) {
         return None;
@@ -81,6 +84,7 @@ pub fn extract_exact_version(req: &VersionReq) -> Option<Version> {
 }
 
 /// Creates an exact version requirement from a version.
+#[must_use]
 pub fn to_exact_requirement(version: &Version) -> VersionReq {
     VersionReq {
         comparators: vec![Comparator {
@@ -96,6 +100,7 @@ pub fn to_exact_requirement(version: &Version) -> VersionReq {
 /// Converts a version to its artifact path string representation.
 ///
 /// This is used when constructing download URLs for packages.
+#[must_use]
 pub fn version_to_artifact_string(version: &Version) -> String {
     if version.pre.is_empty() {
         format!("{}.{}.{}", version.major, version.minor, version.patch)


### PR DESCRIPTION
## Summary

Add `buffrs self-update` command for in-place binary updates from GitHub Releases, following the pattern established by hush2.

## Changes

### New Feature: `buffrs self-update`
- `buffrs self-update` — downloads and installs the latest version
- `buffrs self-update --force` — force reinstall even if current
- `buffrs self-update --check-only` — just check for available updates

### Implementation Details
- Downloads from `globusmedical/ext-buffrs` GitHub Releases
- Uses `gh` CLI for private repo authentication, falls back to direct HTTP
- Platform-specific archive extraction (tar.gz on Linux/macOS, zip on Windows)
- Atomic binary replacement with backup/rollback on failure

### Dependencies Added
- `zip = "2.2"` — for Windows archive extraction
- `reqwest` — added `json` feature for GitHub API response parsing

### Maintenance
- Applied clippy pedantic auto-fixes across codebase
- Version bump to 1.2.6

## Testing
- `buffrs self-update --check-only` — verified against published gm/v1.2.5 release
- `buffrs self-update --help` — help text displays correctly
- `cargo deny check` — all licenses/advisories/bans pass