### PR TITLE
fix: preserve edition in publish and support virtual Artifactory repos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -60,15 +75,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -292,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -378,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -412,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -422,11 +446,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -434,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -446,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clru"
@@ -461,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
@@ -1550,7 +1574,7 @@ version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "075e8747af11abcff07d55d98297c9c6c70eb5d6365b25e7b12f02e484935191"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "backtrace",
  "serde",
@@ -2183,9 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2282,9 +2306,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -3369,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3484,9 +3508,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "tower"
@@ -3578,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4377,18 +4401,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "1.2.6"
+version = "1.2.7"
 edition = "2021"
 description = "Modern protobuf package management"
 authors = [

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -103,6 +103,7 @@ impl From<Edition> for &'static str {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum RawManifest {
     Canary {
+        edition: Edition,
         package: Option<PackageManifest>,
         dependencies: DependencyMap,
     },
@@ -129,7 +130,7 @@ impl RawManifest {
 
     fn edition(&self) -> Edition {
         match self {
-            Self::Canary { .. } => Edition::Canary,
+            Self::Canary { edition, .. } => edition.clone(),
             Self::Unknown { .. } => Edition::Unknown,
         }
     }
@@ -146,11 +147,13 @@ mod serializer {
         {
             match *self {
                 RawManifest::Canary {
+                    ref edition,
                     ref package,
                     ref dependencies,
                 } => {
+                    let edition_str: &str = edition.clone().into();
                     let mut s = serializer.serialize_struct("Canary", 3)?;
-                    s.serialize_field("edition", CANARY_EDITION)?;
+                    s.serialize_field("edition", edition_str)?;
                     s.serialize_field("package", package)?;
                     s.serialize_field("dependencies", dependencies)?;
                     s.end()
@@ -221,13 +224,15 @@ mod deserializer {
                         });
                     };
 
-                    match Edition::from(edition.as_str()) {
+                    let parsed_edition = Edition::from(edition.as_str());
+                    match parsed_edition {
                         Edition::Canary | Edition::Canary10 | Edition::Canary09 | Edition::Canary08 | Edition::Canary07 => Ok(RawManifest::Canary {
+                            edition: parsed_edition,
                             package,
                             dependencies,
                         }),
                         Edition::Unknown => Err(de::Error::custom(
-                            format!("unsupported manifest edition, supported editions of {} are: {CANARY_EDITION}", env!("CARGO_PKG_VERSION"))
+                            format!("unsupported manifest edition '{}', supported editions of buffrs {} are: {CANARY_EDITION}, 0.10, 0.9, 0.8, 0.7", edition, env!("CARGO_PKG_VERSION"))
                         )),
                     }
                 }
@@ -252,6 +257,7 @@ impl From<Manifest> for RawManifest {
             | Edition::Canary09
             | Edition::Canary08
             | Edition::Canary07 => RawManifest::Canary {
+                edition: manifest.edition,
                 package: manifest.package,
                 dependencies,
             },
@@ -924,6 +930,35 @@ lib-algo-base = { version = "=0.1.3-SPINE-4384", repository = "grpc" }
                 );
             }
             other => panic!("expected Remote dependency, got {:?}", other),
+        }
+    }
+
+    /// Regression test: edition must survive a parse → serialize round-trip.
+    ///
+    /// Before the fix, `RawManifest::Canary` did not store the parsed edition
+    /// and the serializer hardcoded `CANARY_EDITION` ("0.50"), so any manifest
+    /// with `edition = "0.10"` would be rewritten to `edition = "0.50"`.
+    #[test]
+    fn edition_preserved_on_roundtrip() {
+        for edition in &["0.10", "0.9", "0.8", "0.7", "0.50"] {
+            let input = format!(
+                r#"edition = "{edition}"
+
+[package]
+type = "lib"
+name = "test-pkg"
+version = "1.0.0"
+"#
+            );
+            let manifest = Manifest::try_parse(&input, None)
+                .unwrap_or_else(|e| panic!("should parse edition {edition}: {e}"));
+            let output: String = manifest
+                .try_into()
+                .unwrap_or_else(|e| panic!("should serialize edition {edition}: {e}"));
+            assert!(
+                output.contains(&format!(r#"edition = "{edition}""#)),
+                "Edition {edition} was mutated during round-trip! Output:\n{output}"
+            );
         }
     }
 }

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -184,14 +184,26 @@ impl Artifactory {
 
         let response = self
             .new_request(Method::GET, storage_url.clone())
-            .send()
+            .send_raw()
             .await?;
-        let response: reqwest::Response = response.0;
 
         // A 404 means the package folder doesn't exist yet — return empty
         if response.status() == reqwest::StatusCode::NOT_FOUND {
             tracing::debug!("Package folder not found at {storage_url}, returning empty versions");
             return Ok(Vec::new());
+        }
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(miette!(
+                "unauthorized - please provide registry credentials with `buffrs login`"
+            ));
+        }
+
+        if !response.status().is_success() {
+            return Err(miette!(
+                "unexpected status {} from storage API at {storage_url}",
+                response.status()
+            ));
         }
 
         let response_str = response.text().await.into_diagnostic().wrap_err(miette!(

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -166,79 +166,66 @@ impl Artifactory {
 
     /// Retrieves all available versions of a package from artifactory.
     ///
-    /// Returns a list of all valid semver versions found for the package.
+    /// Uses the Storage API (`/api/storage/{repo}/{name}/`) which supports
+    /// both local and virtual repositories, unlike the Artifact Search API.
     pub async fn list_versions(
         &self,
         repository: String,
         name: PackageName,
     ) -> miette::Result<Vec<Version>> {
-        // Retrieve all packages matching the given name
-        let search_query_url: Url = {
+        let storage_url: Url = {
             let mut uri: url::Url = self.registry.clone().into();
-            uri.set_path("artifactory/api/search/artifact");
-            uri.set_query(Some(&format!("name={name}&repos={repository}")));
+            let base = uri.path().trim_end_matches('/');
+            uri.set_path(&format!("{base}/api/storage/{repository}/{name}/"));
             uri
         };
 
+        tracing::debug!("Listing versions via storage API: {storage_url}");
+
         let response = self
-            .new_request(Method::GET, search_query_url)
+            .new_request(Method::GET, storage_url.clone())
             .send()
             .await?;
         let response: reqwest::Response = response.0;
 
-        let headers = response.headers();
-        let content_type = headers
-            .get(&reqwest::header::CONTENT_TYPE)
-            .ok_or_else(|| miette!("missing content-type header"))?;
-        ensure!(
-            content_type
-                == reqwest::header::HeaderValue::from_static(
-                    "application/vnd.org.jfrog.artifactory.search.ArtifactSearchResult+json"
-                ),
-            "server response has incorrect mime type: {content_type:?}"
-        );
+        // A 404 means the package folder doesn't exist yet — return empty
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            tracing::debug!("Package folder not found at {storage_url}, returning empty versions");
+            return Ok(Vec::new());
+        }
 
         let response_str = response.text().await.into_diagnostic().wrap_err(miette!(
             "unexpected error: unable to retrieve response payload"
         ))?;
-        let parsed_response = serde_json::from_str::<ArtifactSearchResponse>(&response_str)
+        let parsed_response = serde_json::from_str::<StorageFolderInfo>(&response_str)
             .into_diagnostic()
             .wrap_err(miette!(
-                "unexpected error: response could not be deserialized to ArtifactSearchResponse"
+                "unexpected error: response could not be deserialized to StorageFolderInfo"
             ))?;
 
         tracing::debug!(
-            "List of artifacts found matching the name: {:?}",
-            parsed_response
+            "Storage folder listing for {}/{}: {} children",
+            repository,
+            name,
+            parsed_response.children.len()
         );
 
-        // Extract all valid versions from the artifact URIs
+        let name_str = name.to_string();
         let versions: Vec<Version> = parsed_response
-            .results
+            .children
             .iter()
-            .filter_map(|artifact_search_result| {
-                let uri = artifact_search_result.to_owned().uri;
-                let full_artifact_name = uri
-                    .split('/')
-                    .next_back()
-                    .map(|name_tgz| name_tgz.trim_end_matches(".tgz"));
-                let artifact_version = full_artifact_name.and_then(|artifact_name| {
-                    // Extract version by removing the package name prefix
-                    // Format: {name}-{version}.tgz
-                    let name_str = name.to_string();
-                    artifact_name
-                        .strip_prefix(&name_str)
-                        .and_then(|rest| rest.strip_prefix('-'))
-                        .and_then(|version_str| Version::parse(version_str).ok())
-                });
-
-                // Double-check that the artifact name matches exactly
-                let expected_artifact_name =
-                    artifact_version.clone().map(|av| format!("{name}-{av}"));
-                if full_artifact_name.is_some_and(|actual| {
-                    expected_artifact_name.is_some_and(|expected| expected == actual)
-                }) {
-                    artifact_version
+            .filter(|child| !child.folder)
+            .filter_map(|child| {
+                let filename = child.uri.trim_start_matches('/');
+                let artifact_name = filename.strip_suffix(".tgz")?;
+                let version_str = artifact_name
+                    .strip_prefix(&name_str)
+                    .and_then(|rest| rest.strip_prefix('-'))?;
+                let version = Version::parse(version_str).ok()?;
+                // Round-trip check: ensure the parsed version reconstructs the filename
+                let expected = format!("{name}-{version}");
+                if expected == artifact_name {
+                    Some(version)
                 } else {
                     None
                 }
@@ -494,11 +481,12 @@ impl TryFrom<Response> for ValidatedResponse {
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
-struct ArtifactSearchResponse {
-    results: Vec<ArtifactSearchResult>,
+struct StorageFolderInfo {
+    children: Vec<StorageChild>,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
-struct ArtifactSearchResult {
+struct StorageChild {
     uri: String,
+    folder: bool,
 }


### PR DESCRIPTION
## Summary

Fixes two bugs reported by developer Brandon on `gm-microservices` branch `feature/eiq-feb-2026`.

### Bug 1: Edition rewritten during publish (Fixes #31)

**Problem:** `buffrs publish` rewrites the `edition` field in the tarball's `Proto.toml` to `"0.50"` regardless of the source edition. This caused older buffrs versions (e.g., 0.10.0) to reject downloaded packages with: `unsupported manifest edition, supported editions of 0.10.0 are: 0.10`.

**Root cause:** `RawManifest::Canary` didn't store the parsed `Edition`. The serializer hardcoded `CANARY_EDITION` ("0.50") for all known editions. The `From<Manifest> for RawManifest` conversion collapsed all editions into the `Canary` variant.

**Fix:** Store the `Edition` inside `RawManifest::Canary` and use it during serialization. Added regression test `edition_preserved_on_roundtrip` that tests all 5 known editions (0.7–0.50).

### Bug 2: list_versions fails with virtual Artifactory repos (Fixes #32)

**Problem:** `buffrs install` fails with "no versions of api-spinedb found in repository grpc" even though the package exists on Artifactory.

**Root cause:** `list_versions()` uses the Artifact Search API (`/api/search/artifact?name={name}&repos={repository}`). This API does **not** search virtual Artifactory repositories. When `repos=grpc` (a virtual repo aggregating `grpc-staging` + `grpc-prod`), the API returns empty results.

**Fix:** Switch to the Storage API (`/api/storage/{repo}/{name}/`) which correctly resolves virtual repositories. Parse versions from the `children[].uri` filenames. Return empty `Vec` on 404 (package folder not found).

### Recovery

Both fixes are backward-compatible. Users just need to update to buffrs 1.2.7:
- Existing published packages with `edition = "0.50"` are still accepted (all editions 0.7–0.50 are supported)
- The edition preservation fix prevents future packages from being published with the wrong edition
- The virtual repo fix immediately resolves the "no versions found" error — no republishing needed

### Testing

- `cargo check`: 0 errors (5 pre-existing warnings)
- `cargo test manifest`: 4/4 pass (including new `edition_preserved_on_roundtrip`)
- `cargo test version`: 49/49 pass
- Manually verified Artifactory Storage API returns correct results for `grpc` virtual repo