### PR TITLE
fix: make Proto.lock dependant counts deterministic by deduplicating alias edges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "1.2.8"
+version = "1.2.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "1.2.8"
+version = "1.2.9"
 edition = "2021"
 description = "Modern protobuf package management"
 authors = [

--- a/src/command.rs
+++ b/src/command.rs
@@ -29,7 +29,7 @@ use async_recursion::async_recursion;
 use miette::{bail, ensure, miette, Context, IntoDiagnostic};
 use semver::{Version, VersionReq};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     env,
     path::{Path, PathBuf},
     str::FromStr,
@@ -444,6 +444,43 @@ async fn rewrite_proto_namespaces_in_dir(dir: &Path, version: &Version) -> miett
     Ok(())
 }
 
+fn dependant_counts_by_id(graph: &DependencyGraph) -> HashMap<ResolvedPackageId, usize> {
+    dependant_counts_from_edges(
+        graph.roots(),
+        graph
+            .iter()
+            .map(|(id, resolved)| (id, resolved.depends_on())),
+    )
+}
+
+fn dependant_counts_from_edges<'a>(
+    roots: impl IntoIterator<Item = &'a ResolvedPackageId>,
+    edges: impl IntoIterator<Item = (&'a ResolvedPackageId, &'a [ResolvedPackageId])>,
+) -> HashMap<ResolvedPackageId, usize> {
+    let mut counts = HashMap::new();
+
+    for root in roots {
+        counts.entry(root.clone()).or_insert(1);
+    }
+
+    let mut parents_by_child: HashMap<ResolvedPackageId, HashSet<ResolvedPackageId>> =
+        HashMap::new();
+
+    for (parent_id, dependency_ids) in edges {
+        for dependency_id in dependency_ids {
+            if parents_by_child
+                .entry(dependency_id.clone())
+                .or_default()
+                .insert(parent_id.clone())
+            {
+                *counts.entry(dependency_id.clone()).or_default() += 1;
+            }
+        }
+    }
+
+    counts
+}
+
 /// Installs dependencies
 ///
 /// # Arguments
@@ -490,6 +527,8 @@ pub async fn install(
             .await
             .wrap_err(miette!("dependency resolution failed"))?;
 
+    let dependant_counts = dependant_counts_by_id(&dependency_graph);
+
     let mut locked = Vec::new();
     let mut visited = std::collections::HashSet::new();
 
@@ -500,6 +539,7 @@ pub async fn install(
         store: &PackageStore,
         locked: &mut Vec<LockedPackage>,
         visited: &mut std::collections::HashSet<ResolvedPackageId>,
+        dependant_counts: &HashMap<ResolvedPackageId, usize>,
         prefix: String,
     ) -> miette::Result<()> {
         // Skip if already visited (avoids duplicates in diamond dependencies)
@@ -542,7 +582,6 @@ pub async fn install(
             package,
             registry,
             repository,
-            dependants,
             ..
         } = &resolved
         {
@@ -555,9 +594,14 @@ pub async fn install(
                 })
                 .collect();
 
+            let dependant_count = dependant_counts
+                .get(id)
+                .copied()
+                .ok_or_else(|| miette!("unexpected error: missing dependant count for {id}"))?;
+
             locked.push(
                 package
-                    .lock(registry.clone(), repository.clone(), dependants.len())
+                    .lock(registry.clone(), repository.clone(), dependant_count)
                     .with_resolved_dependencies(resolved_deps),
             );
         }
@@ -574,7 +618,16 @@ pub async fn install(
                 if prefix.is_empty() { "  " } else { &prefix }
             );
 
-            traverse_and_install(dependency, graph, store, locked, visited, new_prefix).await?;
+            traverse_and_install(
+                dependency,
+                graph,
+                store,
+                locked,
+                visited,
+                dependant_counts,
+                new_prefix,
+            )
+            .await?;
         }
 
         Ok(())
@@ -587,6 +640,7 @@ pub async fn install(
             &store,
             &mut locked,
             &mut visited,
+            &dependant_counts,
             String::new(),
         )
         .await?;
@@ -925,7 +979,16 @@ pub mod lock {
 
 #[cfg(test)]
 mod tests {
-    use super::DependencyLocator;
+    use super::{dependant_counts_from_edges, DependencyLocator};
+    use crate::{package::PackageName, resolver::ResolvedPackageId};
+    use semver::Version;
+
+    fn id(name: &str, major: u64, minor: u64, patch: u64) -> ResolvedPackageId {
+        ResolvedPackageId::new(
+            PackageName::new(name).expect("test package name should be valid"),
+            Version::new(major, minor, patch),
+        )
+    }
 
     #[test]
     fn valid_dependency_locator() {
@@ -954,5 +1017,68 @@ mod tests {
             .is_err());
         assert!("repo/pkg@=1#meta".parse::<DependencyLocator>().is_err());
         assert!("repo/PKG@=1.0".parse::<DependencyLocator>().is_err());
+    }
+
+    #[test]
+    fn dependant_counts_include_virtual_root_for_direct_dependencies() {
+        let api_a = id("api-a", 1, 0, 0);
+
+        let counts = dependant_counts_from_edges([&api_a], std::iter::empty());
+
+        assert_eq!(counts.get(&api_a), Some(&1));
+    }
+
+    #[test]
+    fn dependant_counts_count_each_unique_parent_once() {
+        let api_a = id("api-a", 1, 0, 0);
+        let api_b = id("api-b", 1, 0, 0);
+        let lib_shared = id("lib-shared", 1, 0, 0);
+        let api_a_deps = vec![lib_shared.clone()];
+        let api_b_deps = vec![lib_shared.clone()];
+
+        let counts = dependant_counts_from_edges(
+            [&api_a, &api_b],
+            [
+                (&api_a, api_a_deps.as_slice()),
+                (&api_b, api_b_deps.as_slice()),
+            ],
+        );
+
+        assert_eq!(counts.get(&api_a), Some(&1));
+        assert_eq!(counts.get(&api_b), Some(&1));
+        assert_eq!(counts.get(&lib_shared), Some(&2));
+    }
+
+    #[test]
+    fn dependant_counts_deduplicate_duplicate_edges_from_same_parent() {
+        let api_a = id("api-a", 1, 0, 0);
+        let lib_shared = id("lib-shared", 1, 0, 0);
+        let api_a_deps = vec![lib_shared.clone(), lib_shared.clone()];
+
+        let counts = dependant_counts_from_edges([&api_a], [(&api_a, api_a_deps.as_slice())]);
+
+        assert_eq!(counts.get(&api_a), Some(&1));
+        assert_eq!(counts.get(&lib_shared), Some(&1));
+    }
+
+    #[test]
+    fn dependant_counts_track_package_versions_independently() {
+        let api_a = id("api-a", 1, 0, 0);
+        let api_b = id("api-b", 1, 0, 0);
+        let lib_shared_v1 = id("lib-shared", 1, 0, 0);
+        let lib_shared_v2 = id("lib-shared", 2, 0, 0);
+        let api_a_deps = vec![lib_shared_v1.clone()];
+        let api_b_deps = vec![lib_shared_v2.clone()];
+
+        let counts = dependant_counts_from_edges(
+            [&api_a, &api_b],
+            [
+                (&api_a, api_a_deps.as_slice()),
+                (&api_b, api_b_deps.as_slice()),
+            ],
+        );
+
+        assert_eq!(counts.get(&lib_shared_v1), Some(&1));
+        assert_eq!(counts.get(&lib_shared_v2), Some(&1));
     }
 }

--- a/tests/cmd/install/dependants_lock.rs
+++ b/tests/cmd/install/dependants_lock.rs
@@ -1,0 +1,234 @@
+use crate::{with_test_registry, VirtualFileSystem};
+use std::path::Path;
+use toml::Value;
+
+fn write_config(project_dir: &Path) {
+    std::fs::create_dir_all(project_dir.join(".buffrs")).unwrap();
+    std::fs::write(
+        project_dir.join(".buffrs/config.toml"),
+        r#"edition = "0.10"
+"#,
+    )
+    .unwrap();
+}
+
+fn package_dependants(lock_contents: &str, name: &str, version: &str) -> i64 {
+    let lock: Value = toml::from_str(lock_contents).unwrap();
+    let package = lock
+        .get("packages")
+        .and_then(Value::as_array)
+        .unwrap()
+        .iter()
+        .find(|package| {
+            package.get("name").and_then(Value::as_str) == Some(name)
+                && package.get("version").and_then(Value::as_str) == Some(version)
+        })
+        .unwrap_or_else(|| panic!("package {name}@{version} should be present in Proto.lock"));
+
+    package
+        .get("dependants")
+        .and_then(Value::as_integer)
+        .unwrap()
+}
+
+fn publish_lib_shared(root: &Path, buffrs_home: &Path, registry_url: &str) {
+    let package_dir = root.join("lib-shared");
+    std::fs::create_dir(&package_dir).unwrap();
+    write_config(&package_dir);
+    std::fs::write(
+        package_dir.join("Proto.toml"),
+        r#"edition = "0.10"
+
+[package]
+type = "lib"
+name = "lib-shared"
+version = "0.1.0"
+
+[dependencies]
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(package_dir.join("proto")).unwrap();
+    std::fs::write(
+        package_dir.join("proto/shared.proto"),
+        r#"syntax = "proto3";
+package lib.shared;
+
+message SharedMessage {
+    string id = 1;
+}
+"#,
+    )
+    .unwrap();
+
+    crate::cli!()
+        .args([
+            "publish",
+            "--registry",
+            registry_url,
+            "--repository",
+            "libs",
+        ])
+        .env("BUFFRS_HOME", buffrs_home)
+        .current_dir(&package_dir)
+        .assert()
+        .success();
+}
+
+fn publish_api_a_with_duplicate_alias_edges(root: &Path, buffrs_home: &Path, registry_url: &str) {
+    let package_dir = root.join("api-a");
+    std::fs::create_dir(&package_dir).unwrap();
+    write_config(&package_dir);
+    std::fs::write(
+        package_dir.join("Proto.toml"),
+        format!(
+            r#"edition = "0.10"
+
+[package]
+type = "api"
+name = "api-a"
+version = "0.1.0"
+
+[dependencies]
+lib-shared = {{ version = "=0.1.0", registry = "{registry_url}", repository = "libs" }}
+lib-shared-alias = {{ package = "lib-shared", version = "=0.1.0", registry = "{registry_url}", repository = "libs" }}
+"#
+        ),
+    )
+    .unwrap();
+    std::fs::create_dir_all(package_dir.join("proto")).unwrap();
+    std::fs::write(
+        package_dir.join("proto/api_a.proto"),
+        r#"syntax = "proto3";
+package api.a;
+
+service ApiA {}
+"#,
+    )
+    .unwrap();
+
+    crate::cli!()
+        .arg("install")
+        .env("BUFFRS_HOME", buffrs_home)
+        .current_dir(&package_dir)
+        .assert()
+        .success();
+
+    crate::cli!()
+        .args([
+            "publish",
+            "--registry",
+            registry_url,
+            "--repository",
+            "apis",
+        ])
+        .env("BUFFRS_HOME", buffrs_home)
+        .current_dir(&package_dir)
+        .assert()
+        .success();
+}
+
+fn publish_api_b(root: &Path, buffrs_home: &Path, registry_url: &str) {
+    let package_dir = root.join("api-b");
+    std::fs::create_dir(&package_dir).unwrap();
+    write_config(&package_dir);
+    std::fs::write(
+        package_dir.join("Proto.toml"),
+        format!(
+            r#"edition = "0.10"
+
+[package]
+type = "api"
+name = "api-b"
+version = "0.1.0"
+
+[dependencies]
+lib-shared = {{ version = "=0.1.0", registry = "{registry_url}", repository = "libs" }}
+"#
+        ),
+    )
+    .unwrap();
+    std::fs::create_dir_all(package_dir.join("proto")).unwrap();
+    std::fs::write(
+        package_dir.join("proto/api_b.proto"),
+        r#"syntax = "proto3";
+package api.b;
+
+service ApiB {}
+"#,
+    )
+    .unwrap();
+
+    crate::cli!()
+        .arg("install")
+        .env("BUFFRS_HOME", buffrs_home)
+        .current_dir(&package_dir)
+        .assert()
+        .success();
+
+    crate::cli!()
+        .args([
+            "publish",
+            "--registry",
+            registry_url,
+            "--repository",
+            "apis",
+        ])
+        .env("BUFFRS_HOME", buffrs_home)
+        .current_dir(&package_dir)
+        .assert()
+        .success();
+}
+
+#[test]
+fn duplicate_alias_edges_do_not_inflate_lockfile_dependants() {
+    with_test_registry(|registry_url| {
+        let vfs = VirtualFileSystem::empty();
+        let buffrs_home = vfs.root().join("$HOME");
+        let root = vfs.root();
+
+        publish_lib_shared(&root, &buffrs_home, registry_url);
+        publish_api_a_with_duplicate_alias_edges(&root, &buffrs_home, registry_url);
+        publish_api_b(&root, &buffrs_home, registry_url);
+
+        let consumer_dir = root.join("consumer");
+        std::fs::create_dir(&consumer_dir).unwrap();
+        write_config(&consumer_dir);
+        std::fs::write(
+            consumer_dir.join("Proto.toml"),
+            format!(
+                r#"edition = "0.10"
+
+[dependencies]
+api-a = {{ version = "=0.1.0", registry = "{registry_url}", repository = "apis" }}
+api-b = {{ version = "=0.1.0", registry = "{registry_url}", repository = "apis" }}
+"#
+            ),
+        )
+        .unwrap();
+        std::fs::create_dir_all(consumer_dir.join("proto")).unwrap();
+
+        crate::cli!()
+            .arg("install")
+            .env("BUFFRS_HOME", &buffrs_home)
+            .current_dir(&consumer_dir)
+            .assert()
+            .success();
+
+        let first_lock = std::fs::read_to_string(consumer_dir.join("Proto.lock")).unwrap();
+
+        assert_eq!(package_dependants(&first_lock, "api-a", "0.1.0"), 1);
+        assert_eq!(package_dependants(&first_lock, "api-b", "0.1.0"), 1);
+        assert_eq!(package_dependants(&first_lock, "lib-shared", "0.1.0"), 2);
+
+        crate::cli!()
+            .arg("install")
+            .env("BUFFRS_HOME", &buffrs_home)
+            .current_dir(&consumer_dir)
+            .assert()
+            .success();
+
+        let second_lock = std::fs::read_to_string(consumer_dir.join("Proto.lock")).unwrap();
+        assert_eq!(first_lock, second_lock);
+    });
+}

--- a/tests/cmd/install/mod.rs
+++ b/tests/cmd/install/mod.rs
@@ -1,3 +1,4 @@
+mod dependants_lock;
 mod empty;
 mod local;
 mod local_transitive;


### PR DESCRIPTION
Closes #35

## Problem
When a package depends on the same package via both direct reference and package alias (e.g., \lib-shared\ and \lib-shared-alias = {package = lib-shared, ...}\), duplicate edges appear in the DependencyGraph during graph traversal, causing dependants count to inflate incorrectly.

## Solution  
Compute dependant counts deterministically from the final resolved DependencyGraph using unique parent-child edge deduplication.

## Changes
- **src/command.rs**: New \dependant_counts_by_id()\ and \dependant_counts_from_edges()\ functions
- **tests/cmd/install/dependants_lock.rs**: Regression test for issue #35
- **Cargo.toml**: Version bump 1.2.8 → 1.2.9
- **Cargo.lock**: Updated with rustls-webpki 0.103.13 (RUSTSEC-2026-0104 fix)

## Testing
✅ Unit tests (4 new): Deduplication logic verified
✅ E2E regression test (1 new): Confirms second install produces identical lockfile
✅ All 121 unit tests passed
✅ All 21 e2e tests passed
✅ Code quality: format, clippy, cargo deny all passing