### PR TITLE
fix: suppress login prompt for piped stdin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,55 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo install typos-cli@=1.16.26 --locked || true
       - run: typos
+
+  # Auto-tag releases when merging to main-gm.
+  # Pushes a gm/v{x.y.z} tag matching the Cargo.toml version, which triggers release.yml.
+  # Requires GH_PAT_REPO_ACCESS secret (a PAT with contents:write) so the tag push
+  # can cascade to the release workflow. GITHUB_TOKEN would be silently suppressed.
+  tag-release:
+    if: github.event_name == 'push' && github.ref_name == 'main-gm'
+    needs: [fmt, deny, typos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from Cargo.toml
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(grep -oP '^version = "\K[^"]+' Cargo.toml)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=gm/v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: check_tag
+        shell: bash
+        run: |
+          TAG="gm/v${{ steps.version.outputs.version }}"
+          if git tag -l "$TAG" | grep -q . || git ls-remote origin "refs/tags/$TAG" 2>/dev/null | grep -q .; then
+            echo "Tag $TAG already exists — skipping"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.check_tag.outputs.exists == 'false'
+        shell: bash
+        env:
+          GIT_PAT: ${{ secrets.GH_PAT_REPO_ACCESS }}
+        run: |
+          if [ -z "${GIT_PAT}" ]; then
+            echo "::warning title=Missing GH_PAT_REPO_ACCESS secret::A PAT is required so the gm/v* tag push triggers release.yml. Without it, the tag was NOT pushed."
+            exit 0
+          fi
+          TAG="gm/v${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git remote set-url origin "https://x-access-token:${GIT_PAT}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin "$TAG"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "1.2.8"
+version = "1.2.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2839,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "1.2.8"
+version = "1.2.9"
 edition = "2021"
 description = "Modern protobuf package management"
 authors = [

--- a/src/command.rs
+++ b/src/command.rs
@@ -31,6 +31,7 @@ use semver::{Version, VersionReq};
 use std::{
     collections::HashMap,
     env,
+    io::IsTerminal,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -869,7 +870,9 @@ pub async fn login(
     let token = if let Some(token) = token {
         token
     } else {
-        tracing::info!(":: please enter your artifactory token:");
+        if std::io::stdin().is_terminal() {
+            tracing::info!(":: please enter your artifactory token:");
+        }
 
         let mut raw = String::new();
         let mut reader = BufReader::new(io::stdin());

--- a/tests/cmd/login/stdout.log
+++ b/tests/cmd/login/stdout.log
@@ -1,1 +1,0 @@
-:: please enter your artifactory token:


### PR DESCRIPTION
## Summary

Suppress the `buffrs login` prompt when stdin is piped, while preserving the interactive prompt for terminal users.

## Root cause

`buffrs login` printed `:: please enter your artifactory token:` whenever `--token` was not provided, even when stdin was non-interactive. That made automation logs look interactive even though login was succeeding normally.

## Changes

- **`src/command.rs`**: only print the login prompt when stdin is a terminal
- **`tests/cmd/login/stdout.log`**: update fixture expectation (no prompt for piped stdin)
- **`.github/workflows/ci.yml`**: new `tag-release` job auto-creates `gm/v{x.y.z}` tags on push to `main-gm`
- **`Cargo.toml`**: bump buffrs from 1.2.8 to 1.2.9
- **`Cargo.lock`**: update `rustls-webpki` to 0.103.13 (cargo deny)

## Auto-tagging

When a version-bump PR is merged to `main-gm`, the `tag-release` job:
1. Extracts the version from `Cargo.toml`
2. Checks if `gm/v{version}` already exists
3. Creates and pushes the tag using `GH_PAT_REPO_ACCESS`

This triggers `release.yml`, which builds and publishes cross-platform release artifacts.

> [!IMPORTANT]
> The repo needs the `GH_PAT_REPO_ACCESS` secret (PAT with `contents:write`). Only PATs can push tags that cascade to the release workflow.

## Validation

- `cargo test --test e2e cmd::login::fixture`
- `cargo fmt --all -- --check`
- `cargo deny --log-level error check --hide-inclusion-graph`
- `cargo clippy --workspace -- -W clippy::pedantic ...` (no new errors)
